### PR TITLE
fix(docs): swap to icons that exist in Hextra v0.12.2

### DIFF
--- a/docs/site/content/_index.md
+++ b/docs/site/content/_index.md
@@ -63,16 +63,16 @@ toc: false
 
 ## Install
 
-{{< tabs items="Homebrew,Docker,go install,Source" >}}
+{{< tabs >}}
 
-  {{< tab >}}
+  {{< tab name="Homebrew" >}}
   ```bash
   brew install go-steer/cogo/cogo
   cogo --version
   ```
   {{< /tab >}}
 
-  {{< tab >}}
+  {{< tab name="Docker" >}}
   ```bash
   docker pull ghcr.io/go-steer/cogo:latest
   docker run --rm -it -v "$PWD:/work" -w /work \
@@ -80,13 +80,13 @@ toc: false
   ```
   {{< /tab >}}
 
-  {{< tab >}}
+  {{< tab name="go install" >}}
   ```bash
   go install github.com/go-steer/cogo/cmd/cogo@latest
   ```
   {{< /tab >}}
 
-  {{< tab >}}
+  {{< tab name="Source" >}}
   ```bash
   git clone https://github.com/go-steer/cogo
   cd cogo

--- a/docs/site/content/docs/_index.md
+++ b/docs/site/content/docs/_index.md
@@ -8,10 +8,10 @@ sidebar:
 Welcome to the Cogo documentation. Cogo is a terminal-native agentic CLI for Go developers — like Claude Code, but built in Go on the [Google ADK](https://github.com/google/adk-go) and Gemini 3.x.
 
 {{< cards >}}
-  {{< card link="getting-started/" title="Getting Started" subtitle="Install, authenticate, run your first prompt." icon="rocket-launch" >}}
+  {{< card link="getting-started/" title="Getting Started" subtitle="Install, authenticate, run your first prompt." icon="lightning-bolt" >}}
   {{< card link="user-guide/" title="User Guide" subtitle="Interactive TUI, slash commands, file references, models." icon="book-open" >}}
   {{< card link="configuration/" title="Configuration" subtitle="The .agents/ directory: config.json, mcp.json, skills, memory." icon="cog" >}}
-  {{< card link="tools/" title="Built-in Tools" subtitle="Reference for read_file, write_file, edit_file, bash, todo." icon="wrench" >}}
+  {{< card link="tools/" title="Built-in Tools" subtitle="Reference for read_file, write_file, edit_file, bash, todo." icon="chip" >}}
   {{< card link="observability/" title="Observability" subtitle="OpenTelemetry, session transcripts, debug logging." icon="chart-bar" >}}
   {{< card link="development/" title="Development" subtitle="Local CI, contributing, license headers." icon="code" >}}
 {{< /cards >}}

--- a/docs/site/content/docs/observability/_index.md
+++ b/docs/site/content/docs/observability/_index.md
@@ -10,5 +10,5 @@ Cogo has three observability surfaces — pick whichever matches what you're inv
 {{< cards >}}
   {{< card link="telemetry/" title="OpenTelemetry" subtitle="Console + OTLP exporters covering the agent loop, tools, and provider calls." icon="chart-bar" >}}
   {{< card link="transcripts/" title="Session Transcripts" subtitle="JSON dump of every interactive session, written on exit." icon="document" >}}
-  {{< card link="debug-logging/" title="Debug Logging" subtitle="--debug swaps slog to a JSONL handler under .agents/logs/." icon="bug-ant" >}}
+  {{< card link="debug-logging/" title="Debug Logging" subtitle="--debug swaps slog to a JSONL handler under .agents/logs/." icon="beaker" >}}
 {{< /cards >}}


### PR DESCRIPTION
Hextra v0.12.2 ships heroicons v1; my landing page used three v2-only names (rocket-launch / wrench / bug-ant) which broke the GitHub Pages build. Swap to the v1-equivalents already in the theme:

- rocket-launch → lightning-bolt (Getting Started card)
- wrench       → chip            (Built-in Tools card)
- bug-ant      → beaker          (Debug Logging card)

Also migrate the landing page's `tabs items=` shortcode to the per-tab `name=` form (`items=` was deprecated upstream in the same release).