### PR TITLE
docs: add ROADMAP, CONTRIBUTING, and CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,23 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its code of conduct.
+
+The full text — including the standards we hold ourselves to, the scope in which it applies, the enforcement guidelines, and the responsibilities of project maintainers — lives at the link above. We adopt it as written.
+
+## Scope
+
+This Code of Conduct applies in all project spaces, including the GitHub repository (issues, pull requests, discussions, code reviews, commit messages), and any public spaces where someone is representing the project or its community.
+
+## Reporting
+
+If you experience or witness behavior that violates this Code of Conduct, please report it by emailing **gari.r.singh@gmail.com**. Reports will be reviewed and investigated promptly and fairly. All reports will be kept confidential.
+
+When reporting, include as much detail as you can: what happened, where, when, who was involved, and any links or screenshots that help establish context. You don't need to have a complete account — partial reports are still useful.
+
+## Enforcement
+
+Project maintainers are responsible for clarifying and enforcing the standards. They may take any action they deem appropriate, up to and including a temporary or permanent ban from the project's spaces, in line with the Contributor Covenant's [Enforcement Guidelines](https://www.contributor-covenant.org/version/2/1/code_of_conduct/#enforcement-guidelines).
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/), available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html. Translations are available at https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing to cogo
+
+Thanks for your interest in contributing! This file is the table of contents — most of the detail lives in `dev/README.md` and the docs.
+
+By participating in this project you agree to abide by the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Reporting bugs and requesting features
+
+- **Bugs:** [open an issue](https://github.com/go-steer/cogo/issues/new) and include the `cogo --version` output, your OS / Go version, the model + provider you're using, and the smallest set of steps that reproduces the problem. A `--debug` JSONL log (under `.agents/logs/`) is gold if you can attach a redacted snippet.
+- **Feature requests:** check the [roadmap](./ROADMAP.md) and the [open milestones](https://github.com/go-steer/cogo/milestones) first — your idea may already be planned. If not, file an issue with the use case (what you're trying to do) before the proposed solution.
+- **Questions / discussion:** [GitHub Discussions](https://github.com/go-steer/cogo/discussions).
+
+## Pull requests
+
+### Before you start
+
+For anything beyond a typo fix or one-line bug, open an issue first so we can agree on the approach. PRs that are aligned upfront merge faster than ones that surface a design disagreement at review time.
+
+### Workflow
+
+1. Fork and branch from `dev` (not `main` — `main` is release-tagged HEAD).
+2. Make your change. Keep the diff focused; unrelated cleanup belongs in a separate PR.
+3. Run the full local CI before pushing:
+   ```bash
+   dev/tools/ci
+   ```
+   This is the same script that runs in GitHub Actions — green locally means green remotely. See [`dev/README.md`](./dev/README.md) for the full layout and how to add new checks.
+4. Open the PR against `dev`. CI runs on the push; merging to `main` is done via release-cut PRs from `dev` and skips CI re-runs (the SHA already has green checks).
+
+### Commit messages — Conventional Commits
+
+The release changelog is auto-generated from commit messages by [goreleaser](https://goreleaser.com/), so the prefix matters:
+
+- `feat:` — user-visible new functionality
+- `fix:` — user-visible bug fix
+- `docs:` — documentation only
+- `test:` — tests only
+- `refactor:` — code change that's neither a feature nor a fix
+- `chore:` / `build:` / `ci:` — repo plumbing, not in the changelog
+
+Optional scope in parens: `feat(tui): ...`, `fix(mcp): ...`. Keep the subject under ~70 chars; put detail in the body.
+
+### Developer Certificate of Origin (DCO)
+
+All commits must be **signed off** under the [Developer Certificate of Origin](https://developercertificate.org/). The DCO is a lightweight assertion that you wrote the patch (or have the right to submit it under the project's Apache-2.0 license) — it's a `Signed-off-by:` trailer in the commit message, not a cryptographic signature.
+
+Sign off by passing `-s` to `git commit`:
+
+```bash
+git commit -s -m "feat(tui): add dim-the-rest scroll mode"
+```
+
+…which appends:
+
+```
+Signed-off-by: Your Name <you@example.com>
+```
+
+The name and email must match your `git config user.name` / `user.email`. If you forget, amend with `git commit --amend -s` (single commit) or rebase with `-x 'git commit --amend -s --no-edit'` (multiple). A DCO check on PRs blocks merge until every commit has a sign-off.
+
+### License headers
+
+Every Go source file must carry the SPDX header:
+
+```
+// Copyright 2026 The Cogo Authors.
+// SPDX-License-Identifier: Apache-2.0
+```
+
+`golangci-lint` enforces this on `.go` files automatically. For new shell or YAML files, run `dev/tools/add-license-headers` once — it's idempotent and only touches files missing the header. See [`dev/README.md`](./dev/README.md#license-headers) for the full rules.
+
+### Tests
+
+- Unit tests live next to the code (`*_test.go`).
+- TUI tests use [`teatest`](https://github.com/charmbracelet/x/tree/main/exp/teatest); see existing tests in `internal/tui/` for the pattern.
+- End-to-end tests against Vertex are gated on `COGO_E2E=1` plus the auth env vars — they don't run in default CI. See the README's [Development section](./README.md#development) for the invocation.
+- A new feature without a test is not done. A new bug fix without a regression test makes it easy for the bug to come back.
+
+## Project layout
+
+- `cmd/cogo/` — main binary entry point.
+- `internal/` — implementation. `agent/`, `tui/`, `tools/`, `mcp/`, `skills/`, `models/`, etc.
+- `docs/` — design and requirements documents.
+- `dev/` — local + CI tooling (run from here, don't reinvent).
+- `.github/workflows/` — thin delegators to `dev/ci/presubmits/`.
+
+For deeper architecture, read [`docs/DESIGN.md`](./docs/DESIGN.md) and the project's own [`AGENTS.md`](./AGENTS.md).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ GOOGLE_CLOUD_LOCATION=... \
 
 ## Documentation
 
+- [`ROADMAP.md`](./ROADMAP.md) — release themes (v0.2.0 → v0.5.0) and links to the GitHub milestones.
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — how to file issues, the PR workflow, DCO sign-off, commit conventions.
+- [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) — Contributor Covenant v2.1.
 - [`docs/REQUIREMENTS.md`](./docs/REQUIREMENTS.md) — V1 scope, functional & non-functional requirements.
 - [`docs/DESIGN.md`](./docs/DESIGN.md) — architecture, configuration, module layout, testing strategy.
 - [`AGENTS.md`](./AGENTS.md) — project memory that `cogo` itself loads when run inside this repo.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,90 @@
+# Roadmap
+
+This is the public direction for `cogo`. The canonical backlog lives in [GitHub milestones](https://github.com/go-steer/cogo/milestones) and individual issues — this file is the high-level shape so you can see where things are headed without scrolling 50 issues.
+
+No dates. Order can shift based on what people actually use and what blockers turn up. Pre-1.0 means breaking changes are allowed, with a documented changelog at each release.
+
+## Vision
+
+`cogo` aims for broad parity with Claude Code's feature surface, expressed as a single static Go binary. The bet is that a TUI agent built on the [Google ADK](https://github.com/google/adk-go) and Gemini, with first-class MCP and Claude-compatible skills, fills a real gap for developers who want one binary in `$PATH` instead of a Python runtime — and who'd rather configure an agent through `.agents/` checked into the repo than through a hosted product. Long-term, the same surface should work against multiple model backends, not just Gemini.
+
+## Current state
+
+**Shipped:** [`v0.1.0`](https://github.com/go-steer/cogo/releases/tag/v0.1.0) — the V1 MVP.
+
+What's in it: interactive TUI + headless `-p` mode, the built-in tool surface (`read_file` / `write_file` / `edit_file` / `list_dir` / `bash` / `todo`) with a permission system, MCP servers (stdio + Streamable HTTP) with schema-driven elicitation, Claude-compatible skills, project memory (`AGENTS.md`), `/model` picker, cost surfacing, OTEL spans, and persisted session transcripts. See the [README highlights](./README.md#highlights) for the full feature list.
+
+## Releases
+
+Each row links to the live milestone — that's where the up-to-date issue list, progress, and any new tickets land.
+
+| Release | Theme | Milestone |
+|---|---|---|
+| **v0.2.0** | Workflow & customization | [milestone](https://github.com/go-steer/cogo/milestone/1) |
+| **v0.3.0** | Multi-provider | [milestone](https://github.com/go-steer/cogo/milestone/2) |
+| **v0.4.0** | Power features | [milestone](https://github.com/go-steer/cogo/milestone/3) |
+| **v0.5.0** | Platform reach | [milestone](https://github.com/go-steer/cogo/milestone/4) |
+
+---
+
+### v0.2.0 — Workflow & customization → [milestone](https://github.com/go-steer/cogo/milestone/1)
+
+The everyday-use polish that V1 deliberately deferred. Plan mode lets the agent propose before it mutates; user-defined slash commands turn repeated prompts into first-class commands; `/resume` reopens a previous session instead of starting fresh; user-global skills and MCP servers (`~/.cogo/`) merge with project-local config.
+
+Major slices:
+- **Plan mode** — config + agent state, mutating-tool gate, `/plan` command + Shift+Tab toggle, approve-plan UI, transcript persistence.
+- **User-defined commands** — discovery loader for `.agents/commands/`, frontmatter parsing, slash dispatch + palette autocomplete.
+- **Resume** — session loader, interactive `/resume` picker, `cogo --resume` CLI flag.
+- **User-global config** — `~/.cogo/skills/` and `~/.cogo/mcp.json` merge layer.
+- **Transcript controls** — `--no-transcript` flag and `session.persist` config.
+
+### v0.3.0 — Multi-provider → [milestone](https://github.com/go-steer/cogo/milestone/2)
+
+Cogo's core wasn't allowed to depend on Gemini-specific types outside the model adapter; v0.3.0 makes that promise real. Anthropic, OpenAI, and Ollama land behind the same `models.Provider` interface, with a published feature matrix so users know what each backend supports.
+
+Major slices:
+- **Provider-agnostic core** — audit `models.Provider` for Gemini-specific assumptions, extract neutral message + tool-call types, publish a feature matrix doc.
+- **Anthropic** — auth, streaming, tool-use translation, pricing table, tests + docs.
+- **OpenAI** — skeleton + streaming + function calling, pricing, tests + docs.
+- **Ollama** — local HTTP backend, tests + docs.
+
+### v0.4.0 — Power features → [milestone](https://github.com/go-steer/cogo/milestone/3)
+
+The deeper Claude Code parity items that need the multi-provider work to be useful. Subagents let the parent delegate scoped work; hooks open the lifecycle to user shell commands; persistent agent-managed memory gives the agent a writable store across sessions. OTEL gains metrics on top of the spans shipped in v0.1.0.
+
+Major slices:
+- **Subagents** — `.agents/agents/<name>.md` discovery, the `subagent` tool, scoped tool allowlist, `/agents` command.
+- **Hooks** — config schema, `PreToolUse`, `PostToolUse`, `OnSessionStart` executors.
+- **Persistent memory** — `.agents/memory/` schema, `memory_set` / `memory_get` / `memory_list` tools, auto-load into the system prompt.
+- **OTEL metrics** — counters (turns, tool calls, errors) and histograms (latency, tokens) on top of the existing spans.
+
+### v0.5.0 — Platform reach → [milestone](https://github.com/go-steer/cogo/milestone/4)
+
+Cogo's V1 ships Linux + macOS binaries and is text-only. v0.5.0 widens that: image input through the TUI, `.deb` / `.rpm` / Nix packages alongside the Homebrew tap, and Windows promoted from "best-effort" to a tier-2 supported target.
+
+Major slices:
+- **Multimodal** — image paste detection in the TUI, file-drop / `@`-image handling, provider passthrough for image parts.
+- **Linux packaging** — Debian/Ubuntu `.deb` via goreleaser, Fedora/RHEL `.rpm`, a Nix flake.
+- **Windows** — include in goreleaser builds, fix PTY + alt-screen quirks, PowerShell fallback for the `bash` tool with an updated denylist.
+
+## Beyond v0.5.0
+
+Aspirational, explicitly unscoped. Listed so the direction is visible, not as a commitment:
+
+- A web UI that drives the same agent core, for share-a-session and remote-work scenarios.
+- IDE integrations (VS Code first) over the same headless transport.
+- A hosted MCP relay so users don't have to run every server locally.
+- Team features: shared skills, shared memory, audit log of agent actions.
+- Richer evaluation harness so provider/model swaps are quantitatively comparable.
+
+## How priorities shift
+
+The version-themed milestones are the working plan, not a contract. Order within a release is liquid — a piece of v0.4.0 may move forward if a user blocks on it, and a low-signal v0.2.0 item may slide. The truth is always the open issues in the relevant milestone; the table above is the rough shape.
+
+## Contribute / suggest
+
+- **Bugs and feature requests:** [open an issue](https://github.com/go-steer/cogo/issues/new/choose).
+- **Discussion / questions:** [GitHub Discussions](https://github.com/go-steer/cogo/discussions).
+- **Code:** see [`dev/README.md`](./dev/README.md) for the local CI pipeline, license-header rules, and contributor checklist. The same `dev/tools/ci` script that runs in GitHub Actions runs locally.
+
+If you're using cogo and a particular roadmap item is the difference between adopting it and not, say so on the relevant issue — that's the strongest signal we have.


### PR DESCRIPTION
ROADMAP.md frames v0.2.0 through v0.5.0 by theme (workflow & customization, multi-provider, power features, platform reach) and links each release to its GitHub milestone, which remains the canonical backlog.

CONTRIBUTING.md collects the contributor workflow that was scattered across dev/README.md and the git log: branch from dev, run dev/tools/ci, Conventional Commits for the auto-generated changelog, DCO sign-off required on every commit, and pointers to the existing license-header tooling.

CODE_OF_CONDUCT.md adopts Contributor Covenant v2.1 by reference and names a contact for reports.

README links all three from the Documentation section.