### PR TITLE
ci: skip Go pipeline on docs-only changes

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,0 +1,58 @@
+# Copyright 2026 The Cogo Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+name: CI (docs-only)
+
+# Companion no-op to ci.yml. ci.yml uses `paths-ignore: ['**/*.md']`, so a
+# docs-only change wouldn't produce the test/lint/tidy/vuln status checks
+# that branch protection on `main` requires. This workflow runs on the same
+# triggers but matches the inverse paths and emits four trivially-green jobs
+# with the same names. Net effect: docs-only PRs satisfy required checks in
+# ~10s instead of running the full Go pipeline.
+#
+# For mixed PRs (code + docs) both workflows run; the real ci.yml's results
+# are what gates the merge — the latest run of each named check wins.
+
+on:
+  push:
+    branches: [main, dev]
+    paths: ['**/*.md']
+  pull_request:
+    branches: [main]
+    paths: ['**/*.md']
+
+concurrency:
+  group: ${{ github.workflow }}-docs-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test
+    if: github.event_name != 'pull_request' || github.head_ref != 'dev'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only change — no Go to test"
+
+  lint:
+    name: lint
+    if: github.event_name != 'pull_request' || github.head_ref != 'dev'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only change — no Go to lint"
+
+  tidy:
+    name: go mod tidy is clean
+    if: github.event_name != 'pull_request' || github.head_ref != 'dev'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only change — go.mod unaffected"
+
+  vuln:
+    name: govulncheck
+    if: github.event_name != 'pull_request' || github.head_ref != 'dev'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only change — no Go to scan"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,10 @@ name: CI
 on:
   push:
     branches: [main, dev]
+    paths-ignore: ['**/*.md']
   pull_request:
     branches: [main]
+    paths-ignore: ['**/*.md']
 
 # Cancel in-progress runs when a new commit lands on the same branch
 # so we don't queue stale tests.


### PR DESCRIPTION
ci.yml gains paths-ignore: ['**/*.md'] on both push and pull_request triggers, so docs-only changes no longer burn CI minutes on Go build/lint/test/vuln.

A naive paths-ignore would break branch protection on main, which requires the test / lint / go mod tidy is clean / govulncheck status checks on every SHA — ignored paths produce no checks. Add a companion ci-docs.yml workflow with the inverse paths filter that emits four trivially-green jobs with the same names. Net effect: docs-only PRs satisfy required checks in ~10s instead of running the full Go pipeline.

Mixed PRs (code + docs) trigger both workflows; the real ci.yml's results gate the merge — the latest run of each named check wins.

The dev → main skip-if guard is preserved on the no-op jobs so the existing SHA-inheritance flow keeps working.