### PR TITLE
chore: drop the dev branch, move to feature-branch workflow

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -15,7 +15,7 @@ name: CI (docs-only)
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
     paths: ['**/*.md']
   pull_request:
     branches: [main]
@@ -31,28 +31,24 @@ permissions:
 jobs:
   test:
     name: test
-    if: github.event_name != 'pull_request' || github.head_ref != 'dev'
     runs-on: ubuntu-latest
     steps:
       - run: echo "docs-only change — no Go to test"
 
   lint:
     name: lint
-    if: github.event_name != 'pull_request' || github.head_ref != 'dev'
     runs-on: ubuntu-latest
     steps:
       - run: echo "docs-only change — no Go to lint"
 
   tidy:
     name: go mod tidy is clean
-    if: github.event_name != 'pull_request' || github.head_ref != 'dev'
     runs-on: ubuntu-latest
     steps:
       - run: echo "docs-only change — go.mod unaffected"
 
   vuln:
     name: govulncheck
-    if: github.event_name != 'pull_request' || github.head_ref != 'dev'
     runs-on: ubuntu-latest
     steps:
       - run: echo "docs-only change — no Go to scan"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
     paths-ignore: ['**/*.md']
   pull_request:
     branches: [main]
@@ -27,18 +27,10 @@ env:
 # dev/ci/presubmits/. The same script is what `dev/tools/ci` runs
 # locally, so a green local run is the same green run as remote CI.
 # Keep the wiring boring — logic lives in dev/tools/, not in YAML.
-#
-# `if: !skip-dev-pr` on every job: when a PR is opened from `dev` to
-# `main`, every job is skipped because the same HEAD SHA already has
-# green status checks from the `dev` push. Status checks are SHA-scoped,
-# so branch protection on `main` (which requires `test` / `lint` /
-# `tidy` / `vuln`) is satisfied by the checks already attached to that
-# SHA. PRs from feature branches or forks still run CI normally.
 
 jobs:
   test:
     name: test
-    if: github.event_name != 'pull_request' || github.head_ref != 'dev'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -78,7 +70,6 @@ jobs:
 
   lint:
     name: lint
-    if: github.event_name != 'pull_request' || github.head_ref != 'dev'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -102,7 +93,6 @@ jobs:
 
   tidy:
     name: go mod tidy is clean
-    if: github.event_name != 'pull_request' || github.head_ref != 'dev'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -115,7 +105,6 @@ jobs:
 
   vuln:
     name: govulncheck
-    if: github.event_name != 'pull_request' || github.head_ref != 'dev'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,14 +18,15 @@ For anything beyond a typo fix or one-line bug, open an issue first so we can ag
 
 ### Workflow
 
-1. Fork and branch from `dev` (not `main` — `main` is release-tagged HEAD).
+1. Fork and create a short-lived feature branch off `main` (e.g. `feat/plan-mode`, `fix/mcp-leak`, `docs/install-snippet`).
 2. Make your change. Keep the diff focused; unrelated cleanup belongs in a separate PR.
 3. Run the full local CI before pushing:
    ```bash
    dev/tools/ci
    ```
    This is the same script that runs in GitHub Actions — green locally means green remotely. See [`dev/README.md`](./dev/README.md) for the full layout and how to add new checks.
-4. Open the PR against `dev`. CI runs on the push; merging to `main` is done via release-cut PRs from `dev` and skips CI re-runs (the SHA already has green checks).
+4. Open the PR against `main`. CI runs on the PR; the four required status checks (`test`, `lint`, `go mod tidy is clean`, `govulncheck`) gate the merge. Docs-only PRs satisfy these checks via a companion no-op workflow without running the full Go pipeline.
+5. Merge with **Rebase and merge** (the only PR merge option enabled). `main` stays linear.
 
 ### Commit messages — Conventional Commits
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -60,24 +60,23 @@ dev/
 That's it — the delegator pattern means the GitHub workflow never has
 to know what the check actually does.
 
-## CI on `dev` → `main` PRs
+## CI on PRs
 
-Pushing to `dev` runs the full CI pipeline. When you then open a PR
-from `dev` to `main`, the CI jobs are **skipped** — the same HEAD SHA
-already has green status checks from the `dev` push, and status checks
-are SHA-scoped, so branch protection on `main` is satisfied without
-re-running.
+Open a PR against `main` from a short-lived feature branch (e.g.
+`feat/plan-mode`, `fix/mcp-leak`). CI runs on the PR; merging is
+gated on the four required status checks.
 
 For this to actually gate merges, the repo's branch protection on
 `main` must require these checks (settings → branches → main):
 
 - `test`
 - `lint`
-- `tidy`
-- `vuln`
+- `go mod tidy is clean`
+- `govulncheck`
 
-PRs from feature branches or forks (any HEAD that isn't `dev`) still
-run CI normally.
+Docs-only PRs (`**/*.md`) are handled by the companion `ci-docs.yml`
+workflow, which emits the same four check names trivially-green so
+branch protection is satisfied without running the full Go pipeline.
 
 ## License headers
 

--- a/docs/SLICES.md
+++ b/docs/SLICES.md
@@ -6,7 +6,7 @@ The full V1 scope is in [`REQUIREMENTS.md`](./REQUIREMENTS.md); the architecture
 
 | Slice | Status | Outcome |
 |------:|--------|---------|
-| 1 | ✅ shipped on `dev` | `cogo -p "<prompt>"` runs end-to-end against Gemini |
+| 1 | ✅ shipped | `cogo -p "<prompt>"` runs end-to-end against Gemini |
 | 2 | next | `cogo` opens an interactive Bubble Tea TUI with streaming markdown |
 | 3 |  | Agent gains tools (file / shell / web) gated by the permission system |
 | 4 |  | Feature-complete V1 — MCP, skills, memory, slash commands, cost tracking, `cogo init` |


### PR DESCRIPTION
The dev/main two-branch model added ceremony without value for a project where releasability is enforced by tags + goreleaser, not by which branch the work lives on. Switching to short-lived feature branches off main: same safety, fewer steps, no drift to manage.

Changes:

- ci.yml: drop `dev` from push triggers; remove the per-job skip-if that was only needed for the dev → main PR SHA-inheritance trick.
- ci-docs.yml: same.
- dev/README.md: replace the "CI on dev → main PRs" section with a brief "CI on PRs" note. Fix the required-check names (the doc shortened tidy/vuln; branch protection actually requires the full display names go mod tidy is clean / govulncheck).
- CONTRIBUTING.md: update the workflow section to "branch off main"
  + "PR against main" + note that Rebase and merge is now the only enabled merge method.
- docs/SLICES.md: drop the historical "shipped on dev" note from Slice 1 — dev is going away.