### PR TITLE
feat(tui): mouse-wheel scroll with runtime /mouse toggle

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,6 +105,22 @@ type OTELConfig struct {
 // UIConfig holds Bubble Tea presentation choices. Activated in Slice 2.
 type UIConfig struct {
 	Theme string `json:"theme,omitempty"` // "auto" | "light" | "dark"
+
+	// Mouse enables terminal mouse capture so the wheel scrolls the
+	// chat viewport. When enabled, plain click-drag no longer selects
+	// text — terminals route around the capture when Shift is held
+	// (Shift-drag to select, copy as usual). Pointer so unset means
+	// "use the default" (true). Toggle at runtime with /mouse.
+	Mouse *bool `json:"mouse,omitempty"`
+}
+
+// MouseEnabled reports whether mouse capture should be on at startup.
+// Defaults to true when the field is unset.
+func (u UIConfig) MouseEnabled() bool {
+	if u.Mouse == nil {
+		return true
+	}
+	return *u.Mouse
 }
 
 // Permission modes.

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -18,6 +18,7 @@ const (
 	SlashMCP     SlashAction = "mcp"
 	SlashSkills  SlashAction = "skills"
 	SlashReload  SlashAction = "reload"
+	SlashMouse   SlashAction = "mouse"
 	SlashUnknown SlashAction = "unknown"
 )
 
@@ -37,6 +38,7 @@ var slashAliases = map[string]SlashAction{
 	"mcp":    SlashMCP,
 	"skills": SlashSkills,
 	"reload": SlashReload,
+	"mouse":  SlashMouse,
 }
 
 // ParseSlash inspects input. If it looks like a slash command (leading
@@ -93,6 +95,7 @@ func HelpText() string {
 		"  /mcp        show configured MCP servers and their status",
 		"  /skills     show discovered skills",
 		"  /reload     re-read .agents/ from disk (mcp.json, skills/, AGENTS.md, config.json)",
+		"  /mouse      toggle mouse-wheel scrolling (or /mouse on|off)",
 		"",
 		"Keys:",
 		"  PgUp/PgDn   scroll chat history",
@@ -105,8 +108,14 @@ func HelpText() string {
 		"  Ctrl+L      reset viewport scroll (history preserved)",
 		"  Ctrl+U      clear the input box",
 		"",
-		"Mouse selection / copy / paste use your terminal's normal behavior.",
-		"",
-		"More commands (/model, /mcp, /skills, /memory, /stats) arrive in a later release.",
+		"Mouse: wheel scrolls the chat when capture is on (the default).",
+		"To select text while capture is on, hold your terminal's bypass",
+		"modifier while dragging:",
+		"  Shift   most Linux/Windows terminals, WezTerm, Alacritty, Kitty",
+		"  Option  iTerm2, Ghostty, VS Code's integrated terminal",
+		"  Fn      Apple Terminal.app",
+		"VS Code on macOS also needs `terminal.integrated.macOptionClickForcesSelection: true`",
+		"in settings.json before Option-drag will bypass capture.",
+		"Or run /mouse off to give plain drag back to the terminal.",
 	}, "\n")
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -59,11 +59,11 @@ func DefaultKeyMap() KeyMap {
 		),
 		LineUp: key.NewBinding(
 			key.WithKeys("up"),
-			key.WithHelp("↑", "scroll up (when input empty)"),
+			key.WithHelp("↑", "recall previous prompt (when input empty)"),
 		),
 		LineDown: key.NewBinding(
 			key.WithKeys("down"),
-			key.WithHelp("↓", "scroll down (when input empty)"),
+			key.WithHelp("↓", "recall next prompt (when navigating history)"),
 		),
 		ConfirmAllowOnce: key.NewBinding(
 			key.WithKeys("y"),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -133,6 +133,11 @@ type Model struct {
 	// True when the user just hit Ctrl+C while idle once. Second press exits.
 	pendingExit bool
 
+	// mouseEnabled mirrors whether the program is currently capturing
+	// mouse events. Toggled by /mouse, which dispatches the matching
+	// tea.EnableMouseCellMotion / tea.DisableMouse command.
+	mouseEnabled bool
+
 	// AlwaysAllow is invoked when the user picks "always allow" in the
 	// permission modal. The host (TUI launcher) plugs in a function
 	// that persists the pattern to .agents/config.json. May be nil in

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -60,6 +60,7 @@ func allSlashItems() []paletteItem {
 		{Display: "/mcp", Value: "/mcp", Hint: "configured MCP servers + status"},
 		{Display: "/skills", Value: "/skills", Hint: "discovered skill bundles"},
 		{Display: "/reload", Value: "/reload", Hint: "re-read .agents/ from disk"},
+		{Display: "/mouse", Value: "/mouse", Hint: "toggle mouse-wheel scrolling"},
 		{Display: "/clear", Value: "/clear", Hint: "clear chat history"},
 		{Display: "/quit", Value: "/quit", Hint: "exit Cogo"},
 	}

--- a/internal/tui/program.go
+++ b/internal/tui/program.go
@@ -232,10 +232,16 @@ func Run(ctx context.Context, cfg *config.Config, agentsDir string) (int, error)
 		return appendPathScope(agentsDir, req.PersistKey)
 	}
 
-	// Note: deliberately NOT enabling tea.WithMouseCellMotion — capturing
-	// mouse events globally breaks terminal-native text selection (copy /
-	// paste) and makes mouse interaction in the input area feel wrong.
-	p := tea.NewProgram(m, tea.WithAltScreen())
+	// Mouse capture wires the wheel to viewport scrolling. Capturing
+	// mouse events also takes plain click-drag away from the terminal's
+	// native text selection, so users hold Shift to select. Disable via
+	// `ui.mouse: false` in config or /mouse off at runtime.
+	opts := []tea.ProgramOption{tea.WithAltScreen()}
+	m.mouseEnabled = cfg.UI.MouseEnabled()
+	if m.mouseEnabled {
+		opts = append(opts, tea.WithMouseCellMotion())
+	}
+	p := tea.NewProgram(m, opts...)
 	m.SetProgram(p)
 	prompter.(*tuiPrompter).send = p
 	elicitor.attach(p)

--- a/internal/tui/program_test.go
+++ b/internal/tui/program_test.go
@@ -91,8 +91,8 @@ func TestProgram_HelpCommandShowsHelp(t *testing.T) {
 	// the viewport autoscrolls to the latest message, so anything near
 	// the start ("Slash commands:") may not be in the visible window.
 	teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
-		return bytes.Contains(out, []byte("Mouse selection")) ||
-			bytes.Contains(out, []byte("More commands"))
+		return bytes.Contains(out, []byte("Hold Shift while dragging")) ||
+			bytes.Contains(out, []byte("wheel scrolls the chat"))
 	}, teatest.WithDuration(2*time.Second))
 
 	tm.Send(tea.KeyMsg{Type: tea.KeyCtrlC})

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -23,6 +23,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		return m.handleResize(msg)
+	case tea.MouseMsg:
+		// Forward only wheel events; everything else (clicks, drags,
+		// motion) is dropped so the input area and modals don't react
+		// to stray clicks. Shift-drag bypasses our capture at the
+		// terminal layer, so text selection still works.
+		if tea.MouseEvent(msg).IsWheel() {
+			var cmd tea.Cmd
+			m.viewport, cmd = m.viewport.Update(msg)
+			return m, cmd
+		}
+		return m, nil
 	case tea.KeyMsg:
 		// Elicit modal preempts everything (it can carry a free-text
 		// input that would otherwise eat slash commands).
@@ -616,6 +627,8 @@ func (m *Model) handleSlash(action SlashAction, cmd, args string) (tea.Model, te
 		return m, nil
 	case SlashReload:
 		return m.handleReload()
+	case SlashMouse:
+		return m.handleMouseCommand(args)
 	case SlashModel:
 		return m.handleModelCommand(args)
 	case SlashQuit:
@@ -649,6 +662,50 @@ func (m *Model) handleReload() (tea.Model, tea.Cmd) {
 	m.history.Append(Message{Role: RoleSystem, Text: "Reloaded .agents/ from disk. Memory + MCP servers + skills refreshed; chat history and usage totals preserved."})
 	m.refreshViewport()
 	return m, nil
+}
+
+// handleMouseCommand toggles mouse capture, or sets it explicitly when
+// the user passes "on"/"off". The change applies to the current session
+// only; persistence lives in `ui.mouse` in .agents/config.json.
+func (m *Model) handleMouseCommand(args string) (tea.Model, tea.Cmd) {
+	want := !m.mouseEnabled
+	switch strings.ToLower(strings.TrimSpace(args)) {
+	case "", "toggle":
+		// fall through with the flipped value
+	case "on", "true", "yes", "enable", "enabled":
+		want = true
+	case "off", "false", "no", "disable", "disabled":
+		want = false
+	default:
+		m.history.Append(Message{Role: RoleSystem, Text: fmt.Sprintf(
+			"Usage: /mouse [on|off]. Currently %s.", mouseStateLabel(m.mouseEnabled))})
+		m.refreshViewport()
+		return m, nil
+	}
+	if want == m.mouseEnabled {
+		m.history.Append(Message{Role: RoleSystem, Text: fmt.Sprintf(
+			"Mouse capture already %s.", mouseStateLabel(m.mouseEnabled))})
+		m.refreshViewport()
+		return m, nil
+	}
+	m.mouseEnabled = want
+	var teaCmd tea.Cmd
+	if want {
+		teaCmd = tea.EnableMouseCellMotion
+		m.history.Append(Message{Role: RoleSystem, Text: "Mouse capture on — wheel scrolls the chat. Hold Shift while dragging to select text."})
+	} else {
+		teaCmd = tea.DisableMouse
+		m.history.Append(Message{Role: RoleSystem, Text: "Mouse capture off — plain drag selects text. Use PgUp/PgDn to scroll."})
+	}
+	m.refreshViewport()
+	return m, teaCmd
+}
+
+func mouseStateLabel(on bool) string {
+	if on {
+		return "on"
+	}
+	return "off"
 }
 
 // handleModelCommand handles `/model` (no args → open picker) and

--- a/internal/tui/update_mouse_test.go
+++ b/internal/tui/update_mouse_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The Cogo Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"fmt"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/go-steer/cogo/internal/config"
+)
+
+// TestUpdate_MouseWheelScrollsViewport_NotMouseClicks pins the routing
+// contract for tea.MouseMsg in Model.Update:
+//
+//   - Wheel events MUST reach the viewport so the chat scrolls.
+//   - Non-wheel mouse events (clicks, drags, motion) MUST be dropped so
+//     stray clicks don't disturb scroll position or activate the input.
+//
+// DO NOT "fix" this test by relaxing the assertions if a future change
+// breaks it. A failure here is the same bug users hit when they say
+// "scrolling is broken" — the original incident that motivated mouse
+// capture being wired in the first place. If new code legitimately
+// changes how mouse routing works, replace these assertions with ones
+// that prove the new code path still scrolls and still ignores clicks.
+// Never delete the contract.
+func TestUpdate_MouseWheelScrollsViewport_NotMouseClicks(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.DefaultConfig()
+	m := NewModel(cfg, nil, "dark")
+
+	// Give the viewport a defined size, then load enough history that
+	// the content overflows the visible window — a viewport with all
+	// content already on-screen has no room to scroll.
+	if _, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24}); m.viewport.Height <= 0 {
+		t.Fatalf("setup: viewport height not initialized after WindowSizeMsg")
+	}
+	for i := 0; i < 100; i++ {
+		m.history.Append(Message{Role: RoleUser, Text: fmt.Sprintf("history line %03d", i)})
+	}
+	m.refreshViewport()
+	m.viewport.GotoBottom()
+	if !m.viewport.AtBottom() {
+		t.Fatalf("setup: viewport should start at bottom; YOffset=%d", m.viewport.YOffset)
+	}
+
+	// 1) Wheel-up scrolls away from the bottom.
+	m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelUp})
+	if m.viewport.AtBottom() {
+		t.Fatalf("wheel-up did not scroll the viewport (still at bottom)")
+	}
+	afterWheelUp := m.viewport.YOffset
+
+	// 2) Non-wheel mouse events are ignored — viewport state must not move.
+	m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: 5, Y: 5})
+	m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonRight, X: 5, Y: 5})
+	m.Update(tea.MouseMsg{Action: tea.MouseActionMotion, Button: tea.MouseButtonNone, X: 6, Y: 6})
+	m.Update(tea.MouseMsg{Action: tea.MouseActionRelease, Button: tea.MouseButtonLeft, X: 5, Y: 5})
+	if m.viewport.YOffset != afterWheelUp {
+		t.Fatalf("non-wheel mouse events moved YOffset: was %d, now %d", afterWheelUp, m.viewport.YOffset)
+	}
+
+	// 3) Wheel-down brings us back toward the bottom. Repeat enough to
+	// cover any line-stride the viewport applies per wheel event.
+	for i := 0; i < 200; i++ {
+		m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown})
+	}
+	if !m.viewport.AtBottom() {
+		t.Fatalf("wheel-down did not scroll back to bottom; YOffset=%d", m.viewport.YOffset)
+	}
+}


### PR DESCRIPTION
feat(tui): mouse-wheel scroll with runtime /mouse toggle

c06b73b dropped tea.WithMouseCellMotion to give terminal-native text
selection back, accepting that wheel-scroll went with it. PgUp/PgDn
alone turned out to be too easy to miss — users hit the chat, spin
the wheel, see nothing happen, and conclude scrolling is broken.

Re-enable mouse capture by default and route only wheel events to the
viewport; clicks, drags, and motion are dropped on the floor so stray
input doesn't disturb scroll position. Text selection comes back via
the terminal's bypass modifier (Shift on most Linux/Windows, Option
on iTerm2/Ghostty/VS Code, Fn on Apple Terminal.app) — the convention
every TUI users already know from vim, less, htop.

Behavior is configurable:
- ui.mouse: true|false in .agents/config.json controls startup state
  (default true).
- /mouse [on|off|toggle] flips at runtime via tea.EnableMouseCellMotion
  / tea.DisableMouse. Session-only; persistence stays in config.json.

Drive-bys:
- Fix stale ↑/↓ help in keys.go (still claimed "scroll up/down" after
  ef77373 repurposed those keys for prompt-history recall).
- /help text now lists Shift / Option / Fn per terminal and calls out
  the VS Code terminal.integrated.macOptionClickForcesSelection
  setting that's required before Option-drag bypasses capture there.

A new TestUpdate_MouseWheelScrollsViewport_NotMouseClicks pins the
routing contract: wheel reaches the viewport, non-wheel mouse events
do not. The test header explicitly tells future contributors not to
"fix" the test if it breaks — a failure here is the same UX regression
that prompted the work.