### PR TITLE
fix(tui): clean up markdown rendering for chat output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/exp/teatest v0.0.0-20260430013151-79116d1f37bd
 	github.com/modelcontextprotocol/go-sdk v1.4.1
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.43.0
@@ -29,7 +30,6 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect

--- a/internal/tui/branding.go
+++ b/internal/tui/branding.go
@@ -1,0 +1,45 @@
+// Copyright 2026 The Cogo Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import "github.com/charmbracelet/lipgloss"
+
+// Brand colors. Fixed hex (not AdaptiveColor) because the wordmark is
+// brand identity and shouldn't shift between light/dark terminals.
+var (
+	brandCyan  = lipgloss.Color("#00FFFF")
+	brandEye   = lipgloss.Color("#00CED1") // deeper cyan for the inner 'o'
+	brandGreen = lipgloss.Color("#A7FF00")
+	brandSlate = lipgloss.Color("#6272A4")
+)
+
+// headerBrand renders the persistent brand line shown on the left of
+// the status header: `go-steer / c[o]go █`. The headline is short
+// enough to fit on the same row as the status info on any reasonable
+// terminal width, so we don't waste a viewport row on a separate
+// banner.
+//
+// The trailing block is rendered as a `█` glyph in green rather than a
+// space with a green background + padding. Background + padding plays
+// poorly with some terminals and lipgloss layout (occasional wrapping
+// or the whole header collapsing when JoinHorizontal disagrees with
+// the outer Padding). The glyph approach is one column wide, has no
+// background to mismatch, and renders identically everywhere.
+func headerBrand() string {
+	bracket := lipgloss.NewStyle().Foreground(brandCyan).Bold(true)
+	c := lipgloss.NewStyle().Foreground(brandCyan).Bold(true).Render("c")
+	o := lipgloss.NewStyle().Foreground(brandEye).Bold(true).Render("o")
+	g := lipgloss.NewStyle().Foreground(brandGreen).Render("go")
+	cursor := lipgloss.NewStyle().Foreground(brandGreen).Bold(true).Render("█")
+	org := lipgloss.NewStyle().Foreground(brandSlate).Render("go-steer / ")
+	return org + c + bracket.Render("[") + o + bracket.Render("]") + g + " " + cursor
+}
+
+// emptyStateHint is shown inside the viewport when the chat history is
+// empty. The slate italic matches the brand palette without needing a
+// full splash banner.
+func emptyStateHint() string {
+	return lipgloss.NewStyle().Foreground(brandSlate).Italic(true).
+		Render("> Type a message and hit Enter. /help for commands.")
+}

--- a/internal/tui/branding_test.go
+++ b/internal/tui/branding_test.go
@@ -63,6 +63,25 @@ func TestView_HeaderAlwaysShowsBrandAndStatus(t *testing.T) {
 	}
 }
 
+// TestSpinner_UsesBrandStyle pins the spinner-style wiring. The
+// Styles.Spinner field exists for a reason: the streaming spinner
+// glyph should render in brand cyan + bold, not bubble's default
+// foreground. The bug was that we defined Styles.Spinner but never
+// assigned it to spinner.Model.Style, so spinner.View() always
+// rendered with the default style. DO NOT silence this test —
+// failure means the spinner regressed to default colors and users
+// stop seeing the brand affordance during streaming.
+func TestSpinner_UsesBrandStyle(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultConfig()
+	m := NewModel(cfg, nil, "dark")
+	want := DefaultStyles().Spinner
+	if m.spinner.Style.String() != want.String() {
+		t.Errorf("spinner.Style not wired to Styles.Spinner; got %v want %v",
+			m.spinner.Style, want)
+	}
+}
+
 // TestHeaderBrand_NoControlCharLeaks guards against the cursor block
 // or other styled spans emitting stray newlines into the brand line.
 // A newline inside headerBrand silently breaks the JoinHorizontal in

--- a/internal/tui/branding_test.go
+++ b/internal/tui/branding_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 The Cogo Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/go-steer/cogo/internal/config"
+)
+
+// TestView_HeaderAlwaysShowsBrandAndStatus pins the persistent header
+// contract: the very first row of View() output must carry both the
+// brand wordmark (left) and the model + cwd + provider + mode status
+// info (right), regardless of viewport state.
+//
+// DO NOT silence this test if it breaks. A failure here means users
+// open the TUI and the top of the screen has no header — exactly the
+// regression that motivated this test. If the layout legitimately
+// changes, replace the assertions with ones that prove the new
+// arrangement still shows brand + status; never delete the contract.
+func TestView_HeaderAlwaysShowsBrandAndStatus(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultConfig()
+	for _, size := range []struct {
+		name          string
+		width, height int
+	}{
+		{"tight", 80, 24},
+		{"wide", 160, 40},
+		{"very-narrow", 50, 24},
+	} {
+		size := size
+		t.Run(size.name, func(t *testing.T) {
+			t.Parallel()
+			m := NewModel(cfg, nil, "dark")
+			m.Update(tea.WindowSizeMsg{Width: size.width, Height: size.height})
+			out := m.View()
+			stripped := stripANSI(out)
+			lines := strings.Split(stripped, "\n")
+			if len(lines) == 0 {
+				t.Fatalf("View() empty")
+			}
+			head := lines[0]
+			// Brand wordmark must show.
+			if !strings.Contains(head, "go-steer / c[o]go") {
+				t.Errorf("first row missing brand wordmark; got %q", head)
+			}
+			// Model name must show on the same row.
+			if !strings.Contains(head, cfg.Model.Name) {
+				t.Errorf("first row missing model name %q; got %q", cfg.Model.Name, head)
+			}
+			// Permission mode badge must show on the same row.
+			if !strings.Contains(head, "ask") {
+				t.Errorf("first row missing permission mode; got %q", head)
+			}
+		})
+	}
+}
+
+// TestHeaderBrand_NoControlCharLeaks guards against the cursor block
+// or other styled spans emitting stray newlines into the brand line.
+// A newline inside headerBrand silently breaks the JoinHorizontal in
+// renderHeader and the whole status line collapses.
+func TestHeaderBrand_NoControlCharLeaks(t *testing.T) {
+	t.Parallel()
+	out := headerBrand()
+	if regexp.MustCompile(`\r|\n`).MatchString(out) {
+		t.Errorf("headerBrand() contains a newline; would break renderHeader layout. Raw bytes: %q", out)
+	}
+	stripped := stripANSI(out)
+	if !strings.Contains(stripped, "go-steer / c[o]go") {
+		t.Errorf("headerBrand() missing wordmark after ANSI strip: %q", stripped)
+	}
+}
+
+// TestView_RowCountFitsHeight pins the OTHER invariant that broke the
+// header on a real terminal: View() must return EXACTLY m.height rows.
+// One row over and Bubble Tea's alt-screen scrolls one line, sending
+// the header off the top — exactly what users see when the bug fires.
+// This is easy to break by accident: appending "\n" instead of "" to
+// JoinVertical adds 2 blank rows per newline rather than 1.
+func TestView_RowCountFitsHeight(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultConfig()
+	for _, h := range []int{16, 24, 40, 60} {
+		h := h
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			m := NewModel(cfg, nil, "dark")
+			m.Update(tea.WindowSizeMsg{Width: 100, Height: h})
+			out := m.View()
+			got := strings.Count(out, "\n") + 1
+			if got != h {
+				t.Errorf("View() at height %d returned %d rows; want exactly %d (overflow scrolls the header off the top)", h, got, h)
+			}
+		})
+	}
+}
+
+// TestRenderHeader_FitsWidth pins the structural invariant that broke
+// the header on a real terminal: the rendered first row must be EXACTLY
+// m.width columns wide. If it's even one column wider the terminal
+// wraps it onto a second row, Bubble Tea's screen positioning loses
+// track of the header, and the user opens the TUI with no header at
+// all. DO NOT silence — fix the layout so the line fits.
+func TestRenderHeader_FitsWidth(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultConfig()
+	for _, w := range []int{40, 80, 100, 160, 200} {
+		w := w
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			m := NewModel(cfg, nil, "dark")
+			m.Update(tea.WindowSizeMsg{Width: w, Height: 24})
+			head := m.renderHeader()
+			got := lipgloss.Width(head)
+			if got != w {
+				t.Errorf("renderHeader at width %d returned a row of width %d; want exactly %d (overflow wraps and hides the header on real terminals)", w, got, w)
+			}
+		})
+	}
+}

--- a/internal/tui/markdown.go
+++ b/internal/tui/markdown.go
@@ -3,7 +3,11 @@
 
 package tui
 
-import "github.com/charmbracelet/glamour"
+import (
+	"github.com/charmbracelet/glamour"
+	"github.com/charmbracelet/glamour/ansi"
+	"github.com/charmbracelet/glamour/styles"
+)
 
 // MarkdownRenderer wraps a Glamour TermRenderer to render assistant
 // messages on TurnComplete. Streaming partial chunks bypass this
@@ -32,7 +36,7 @@ func NewMarkdownRenderer(width int, styleName string) (*MarkdownRenderer, error)
 		styleName = "dark"
 	}
 	opts := []glamour.TermRendererOption{
-		glamour.WithStandardStyle(styleName),
+		glamour.WithStyles(cogoStyleConfig(styleName)),
 	}
 	if width > 0 {
 		opts = append(opts, glamour.WithWordWrap(width))
@@ -43,6 +47,82 @@ func NewMarkdownRenderer(width int, styleName string) (*MarkdownRenderer, error)
 	}
 	return &MarkdownRenderer{r: r}, nil
 }
+
+// cogoStyleConfig starts from Glamour's bundled dark/light style and
+// patches a couple of rough edges:
+//
+//  1. H2-H6 in the bundled styles render with the literal "##"/"###"
+//     prefix in the output (e.g. "## Section" stays "## Section").
+//     We strip the prefix and substitute bold + color so heading depth
+//     is still visible without leaking raw markdown to the user. H1 is
+//     left alone — its inverted banner block already strips the "#"
+//     and reads as a heading on its own.
+//
+//  2. Code fences get static separator lines above and below so the
+//     boundaries of a code block are visually obvious. Glamour doesn't
+//     plumb the language tag through to the static prefix/suffix, so
+//     the chrome is generic ("code") rather than per-language.
+func cogoStyleConfig(styleName string) ansi.StyleConfig {
+	cfg := styles.DarkStyleConfig
+	if styleName == "light" {
+		cfg = styles.LightStyleConfig
+	}
+	for level, h := range map[int]*ansi.StyleBlock{
+		2: &cfg.H2,
+		3: &cfg.H3,
+		4: &cfg.H4,
+		5: &cfg.H5,
+		6: &cfg.H6,
+	} {
+		h.Prefix = ""
+		h.Color = strPtr(headingColor(styleName, level))
+		h.Bold = boolPtr(true)
+	}
+	cfg.CodeBlock.BlockPrefix = codeBlockTopBar
+	cfg.CodeBlock.BlockSuffix = codeBlockBottomBar
+	return cfg
+}
+
+// codeBlockTopBar / codeBlockBottomBar bracket fenced code blocks. The
+// top bar carries a "code" label so the separator reads as a deliberate
+// boundary rather than a horizontal rule. The exact glyph counts are
+// arbitrary; they only need to look like a contained block at a glance.
+const (
+	codeBlockTopBar    = "──────── code ────────\n"
+	codeBlockBottomBar = "──────────────────────"
+)
+
+// headingColor returns the 256-color index for heading level n (2-6).
+// Cool-blue palette chosen so headings stay distinct from inline code
+// and bold body text. Lighter shade per level so the visual hierarchy
+// still reads even without indentation differences.
+func headingColor(styleName string, level int) string {
+	if styleName == "light" {
+		switch level {
+		case 2:
+			return "27"
+		case 3:
+			return "33"
+		case 4:
+			return "61"
+		default:
+			return "67"
+		}
+	}
+	switch level {
+	case 2:
+		return "75"
+	case 3:
+		return "39"
+	case 4:
+		return "147"
+	default:
+		return "110"
+	}
+}
+
+func strPtr(s string) *string { return &s }
+func boolPtr(b bool) *bool    { return &b }
 
 // Render applies Glamour to markdown. If the renderer failed to
 // initialize, it returns markdown unchanged so the user still sees

--- a/internal/tui/markdown_test.go
+++ b/internal/tui/markdown_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 The Cogo Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// ansiEscape matches CSI sequences (color/style codes) emitted by
+// Glamour. Stripping these makes string assertions resilient to the
+// per-word styling Glamour wraps content in.
+var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string { return ansiEscape.ReplaceAllString(s, "") }
+
+// TestMarkdownRenderer_HeadingMarkersStripped pins the heading
+// rendering contract: H1-H6 must NOT leave the literal "#"/"##"/"###"
+// prefix in the rendered output. Glamour's bundled "dark" / "light"
+// styles ship with H2-H6 prefixes set to the marker itself; cogo's
+// custom style overrides those (see cogoStyleConfig in markdown.go).
+//
+// DO NOT relax this assertion if it breaks. The user-visible bug is
+// the same one that motivated the fix: assistant messages render with
+// raw "## Section" instead of a styled heading. If a future Glamour
+// upgrade or refactor changes how prefixes work, replace the regex
+// with one that proves the new path still strips them — never delete
+// the contract.
+//
+// TestMarkdownRenderer_CodeBlockSeparators pins the second contract:
+// fenced code blocks must be bracketed by visible separator lines so
+// the chat distinguishes code from prose. Same rule — if the test
+// breaks, prove the new code path still produces visible chrome
+// around code blocks; do not silence the assertion.
+func TestMarkdownRenderer_HeadingMarkersStripped(t *testing.T) {
+	t.Parallel()
+	for _, style := range []string{"dark", "light"} {
+		style := style
+		t.Run(style, func(t *testing.T) {
+			t.Parallel()
+			mr, err := NewMarkdownRenderer(80, style)
+			if err != nil {
+				t.Fatalf("NewMarkdownRenderer(%q): %v", style, err)
+			}
+			src := strings.Join([]string{
+				"# H1 line",
+				"## H2 line",
+				"### H3 line",
+				"#### H4 line",
+				"##### H5 line",
+				"###### H6 line",
+				"",
+				"body paragraph",
+			}, "\n")
+			out := stripANSI(mr.Render(src))
+			// Each leak pattern is unambiguous: real prose wouldn't
+			// produce "## " at the start of a paragraph because the
+			// renderer would have consumed the marker as a heading.
+			for _, leak := range []string{"## H2", "### H3", "#### H4", "##### H5", "###### H6"} {
+				if strings.Contains(out, leak) {
+					t.Errorf("%s style: rendered output still contains %q\nfull output:\n%s", style, leak, out)
+				}
+			}
+			// And the heading text itself must survive — make sure the
+			// fix didn't strip the content along with the marker.
+			for _, want := range []string{"H1 line", "H2 line", "H3 line", "H4 line", "H5 line", "H6 line"} {
+				if !strings.Contains(out, want) {
+					t.Errorf("%s style: rendered output missing %q\nfull output:\n%s", style, want, out)
+				}
+			}
+		})
+	}
+}
+
+func TestMarkdownRenderer_CodeBlockSeparators(t *testing.T) {
+	t.Parallel()
+	for _, style := range []string{"dark", "light"} {
+		style := style
+		t.Run(style, func(t *testing.T) {
+			t.Parallel()
+			mr, err := NewMarkdownRenderer(80, style)
+			if err != nil {
+				t.Fatalf("NewMarkdownRenderer(%q): %v", style, err)
+			}
+			src := "Some prose.\n\n```go\nfunc hi() { println(\"x\") }\n```\n\nMore prose.\n"
+			out := stripANSI(mr.Render(src))
+			// The bar glyphs must show up around the code block. We
+			// check for substrings rather than the full bar to stay
+			// resilient to width/padding tweaks.
+			if !strings.Contains(out, "──── code ────") {
+				t.Errorf("%s style: missing top separator with 'code' label\nfull output:\n%s", style, out)
+			}
+			if !strings.Contains(out, "──────────────────────") {
+				t.Errorf("%s style: missing bottom separator bar\nfull output:\n%s", style, out)
+			}
+			// And the actual code content must still survive.
+			if !strings.Contains(out, "func hi()") {
+				t.Errorf("%s style: code content missing\nfull output:\n%s", style, out)
+			}
+		})
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -200,10 +200,13 @@ func (m *Model) Init() tea.Cmd {
 }
 
 // renderHistory builds the viewport contents from the current history.
-// One block per message, separated by blank lines.
+// One block per message, separated by blank lines. With no messages
+// yet, an empty-state hint stands in so the viewport isn't blank on
+// first launch — the brand wordmark already lives in the persistent
+// header above, so no banner is needed here.
 func (m *Model) renderHistory() string {
 	if m.history.Len() == 0 {
-		return m.styles.System.Render("Type a message and hit Enter. /help for commands, /quit to exit.")
+		return emptyStateHint()
 	}
 	msgs := m.history.Snapshot()
 	parts := make([]string, 0, len(msgs))

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -154,7 +154,7 @@ type Model struct {
 // Glamour's background-color query response to leak into the textarea.
 func NewModel(cfg *config.Config, a *agent.Agent, mdStyle string) *Model {
 	ta := textarea.New()
-	ta.Placeholder = "Type a message, or /help…"
+	ta.Placeholder = "Message · / for commands · @ for files…"
 	ta.ShowLineNumbers = false
 	ta.CharLimit = 0
 	ta.SetHeight(3)
@@ -235,9 +235,9 @@ func (m *Model) renderMessage(msg Message) string {
 		}
 		return text
 	case RoleSystem:
-		return m.styles.System.Render(msg.Display())
+		return m.styles.System.Render("ℹ  " + msg.Display())
 	case RoleError:
-		return m.styles.Error.Render(msg.Display())
+		return m.styles.Error.Render("⚠  " + msg.Display())
 	default:
 		return msg.Display()
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -162,8 +162,10 @@ func NewModel(cfg *config.Config, a *agent.Agent, mdStyle string) *Model {
 
 	vp := viewport.New(0, 0)
 
+	styles := DefaultStyles()
 	sp := spinner.New()
 	sp.Spinner = spinner.Dot
+	sp.Style = styles.Spinner
 
 	md, _ := NewMarkdownRenderer(80, mdStyle) // tightened on first WindowSizeMsg
 
@@ -176,7 +178,7 @@ func NewModel(cfg *config.Config, a *agent.Agent, mdStyle string) *Model {
 		viewport:            vp,
 		spinner:             sp,
 		keys:                DefaultKeyMap(),
-		styles:              DefaultStyles(),
+		styles:              styles,
 		md:                  md,
 		mdStyle:             mdStyle,
 		state:               StateIdle,

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -58,7 +58,8 @@ func DefaultStyles() Styles {
 			BorderForeground(border).
 			Padding(0, 1),
 		Spinner: lipgloss.NewStyle().
-			Foreground(accent),
+			Foreground(brandCyan).
+			Bold(true),
 		Footer: lipgloss.NewStyle().
 			Foreground(muted),
 		Confirm: lipgloss.NewStyle().

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -36,8 +36,7 @@ func DefaultStyles() Styles {
 
 	return Styles{
 		Header: lipgloss.NewStyle().
-			Foreground(muted).
-			Padding(0, 1),
+			Foreground(muted),
 		HeaderAccent: lipgloss.NewStyle().
 			Foreground(accent).
 			Bold(true),

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -275,7 +275,7 @@ func (m *Model) handleResize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 	headerH := 1
 	inputH := m.textarea.Height() + 2 // border lines
 	footerH := 1
-	vpH := m.height - headerH - inputH - footerH
+	vpH := m.height - headerH - inputH - footerH - bottomPad
 	if vpH < 3 {
 		vpH = 3
 	}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -741,6 +741,17 @@ func (m *Model) switchModel(modelID string) (tea.Model, tea.Cmd) {
 		m.refreshViewport()
 		return m, nil
 	}
+	// Reject unknown model IDs up front — the provider builds the model
+	// lazily, so without this check `/model bogus` looks like it
+	// succeeded and only fails on the next prompt with an opaque
+	// API 400. Listing the candidates makes the failure actionable.
+	if indexOfModel(modelID) < 0 {
+		m.history.Append(Message{Role: RoleError, Text: fmt.Sprintf(
+			"Unknown model %q. Try one of: %s",
+			modelID, strings.Join(availableModels(), ", "))})
+		m.refreshViewport()
+		return m, nil
+	}
 	newAgent, err := m.rebuildAgent(modelID)
 	if err != nil {
 		m.history.Append(Message{Role: RoleError, Text: "Switch failed: " + err.Error()})

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -312,11 +312,13 @@ func shortDir(dir string) string {
 }
 
 // modeBadge styles the permission mode so "yolo" stands out — landing
-// in yolo without realizing it should be visually obvious.
+// in yolo without realizing it should be visually obvious. The yolo
+// label gets a leading ⚠ glyph so it's recognizable even on a quick
+// glance at the corner of the header.
 func modeBadge(mode string, st Styles) string {
 	switch mode {
 	case "yolo":
-		return st.Error.Render(mode)
+		return st.Error.Render("⚠ " + mode)
 	case "ask":
 		return st.HeaderAccent.Render(mode)
 	default:

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func homeDir() string {
@@ -57,7 +58,14 @@ func (m *Model) View() string {
 		parts = append(parts, m.renderPalette())
 	}
 	parts = append(parts, input, footer)
-	parts = append(parts, strings.Repeat("\n", bottomPad))
+	// Append bottomPad EMPTY-STRING parts (not a newline string).
+	// JoinVertical splits each part on "\n" — feeding it "\n" yields
+	// two empty rows per newline, blowing the row budget by one and
+	// scrolling the header off the top of the alt-screen. An empty
+	// string contributes exactly one blank row, which is what we want.
+	for i := 0; i < bottomPad; i++ {
+		parts = append(parts, "")
+	}
 	return lipgloss.JoinVertical(lipgloss.Left, parts...)
 }
 
@@ -242,18 +250,50 @@ func (m *Model) renderHeader() string {
 	}
 	cwd := shortDir(m.projectRoot)
 
-	left := fmt.Sprintf("Cogo · %s", m.styles.HeaderAccent.Render(m.cfg.Model.Name))
-	right := fmt.Sprintf("%s · %s · %s", cwd, provider, modeBadge(mode, m.styles))
+	// Header layout: 1-char gutter on each edge + brand on the left +
+	// flexible gap + status on the right. Crucially the assembled line
+	// must end up EXACTLY m.width columns wide — one column over and
+	// the terminal wraps the row, which (because Bubble Tea's screen
+	// positioning assumes a single-row header) scrolls the whole header
+	// off the top of the alt-screen and the user opens the TUI to a
+	// missing header. The Header style has no Padding for the same
+	// reason: it would invisibly add 2 cols on top of our budget.
+	left := headerBrand()
+	// Build the right side incrementally, appending each segment only
+	// if it still fits. Model name is the floor — always shown.
+	const gutter = 1
+	budget := m.width - 2*gutter - lipgloss.Width(left) - 1 // -1 for min gap
+	right := m.styles.HeaderAccent.Render(m.cfg.Model.Name)
+	tryAppend := func(s string) {
+		if lipgloss.Width(right)+lipgloss.Width(s) <= budget {
+			right += s
+		}
+	}
+	// Order matters: append the security-critical mode badge before the
+	// nice-to-haves so a yolo/ask label is the last thing dropped on
+	// narrow terminals.
+	tryAppend(" · " + modeBadge(mode, m.styles))
+	tryAppend(" · " + cwd)
+	tryAppend(" · " + provider)
 	if m.usage != nil {
 		tot := m.usage.Totals()
-		right += fmt.Sprintf(" · σ ↑%d/↓%d/$%s",
-			tot.InputTokens, tot.OutputTokens, formatCost(tot.CostUSD))
+		tryAppend(fmt.Sprintf(" · σ ↑%d/↓%d/$%s",
+			tot.InputTokens, tot.OutputTokens, formatCost(tot.CostUSD)))
 	}
-	gap := m.width - lipgloss.Width(left) - lipgloss.Width(right)
+	gap := m.width - 2*gutter - lipgloss.Width(left) - lipgloss.Width(right)
 	if gap < 1 {
 		gap = 1
 	}
-	return m.styles.Header.Render(left + strings.Repeat(" ", gap) + right)
+	pad := strings.Repeat(" ", gutter)
+	line := pad + left + strings.Repeat(" ", gap) + right + pad
+	// Belt and suspenders: truncate if the math still produced a row
+	// wider than the terminal (e.g., a model name longer than the whole
+	// terminal width). ansi.Truncate is ANSI-aware so it doesn't break
+	// the styled brand spans.
+	if lipgloss.Width(line) > m.width {
+		line = ansi.Truncate(line, m.width, "…")
+	}
+	return m.styles.Header.Render(line)
 }
 
 // shortDir returns the basename of dir prefixed with "~/" when dir is

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -16,6 +16,12 @@ func homeDir() string {
 	return h
 }
 
+// bottomPad reserves blank rows at the bottom of the alt-screen so the
+// footer never sits flush against the terminal edge. handleResize
+// subtracts the same value from the viewport height so total content
+// still matches the screen.
+const bottomPad = 1
+
 // View renders the model as a single string. Layout (top to bottom):
 //
 //	Header
@@ -24,6 +30,7 @@ func homeDir() string {
 //	Input area (textarea inside a rounded border) — replaced by the
 //	  permission modal when a request is pending
 //	Footer (status hint or spinner)
+//	bottomPad blank rows (breathing room)
 func (m *Model) View() string {
 	if m.width == 0 || m.height == 0 {
 		// Pre-resize: avoid drawing into 0×0.
@@ -50,6 +57,7 @@ func (m *Model) View() string {
 		parts = append(parts, m.renderPalette())
 	}
 	parts = append(parts, input, footer)
+	parts = append(parts, strings.Repeat("\n", bottomPad))
 	return lipgloss.JoinVertical(lipgloss.Left, parts...)
 }
 


### PR DESCRIPTION
fix(tui): clean up markdown rendering for chat output

Glamour's bundled `dark` and `light` styles ship two rough edges that
made assistant messages feel unfinished:

1. H2-H6 render with the literal `##`/`###` prefix in the styled
   output. The user reported "raw markdown leaking through" — they
   were right; only H1 strips the marker (it has the inverted-banner
   block style), H2-H6 keep it as part of the styling.

2. Code fences blend into surrounding prose because there's no chrome
   to mark where the block starts and ends. Code is syntax-highlighted
   but otherwise floats free.

cogoStyleConfig (internal/tui/markdown.go) now patches both:

- H2-H6 get prefix="" plus bold + a per-level cool-blue color so
  heading depth is still visually obvious without leaking the marker.
  H1 is unchanged — its banner block already reads cleanly.
- CodeBlock gets static `──────── code ──────── / ──────────────────────`
  separator lines as BlockPrefix/BlockSuffix. The "code" label is
  generic rather than per-language because Glamour's prefix/suffix
  are static strings — they don't get the language tag plumbed
  through. Workable tradeoff for the chrome we wanted; doing better
  would mean forking Glamour.

A "colored box" via CodeBlock background was prototyped first but
abandoned: Glamour renders code via Chroma per-token, the wrap-padding
on the right doesn't inherit the block background, and you end up
with a ragged-right rectangle that looks worse than no box at all.
Notes left in cogoStyleConfig so the next contributor doesn't have to
re-derive the constraint.

A new TestMarkdownRenderer_HeadingMarkersStripped pins both contracts
across `dark` and `light` styles, with a "do not silence this test"
comment to keep future contributors from "fixing" the test instead of
the regression. Verified the test fails when reverted to
`WithStandardStyle`.