### PR TITLE
feat(tui): in-chat rotating "Thinking…" indicator

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -138,6 +138,14 @@ type Model struct {
 	// tea.EnableMouseCellMotion / tea.DisableMouse command.
 	mouseEnabled bool
 
+	// thinkingIdx selects which entry of thinkingPhrases is currently
+	// flashing in the chat while we wait for the model. A thinkingTick
+	// scheduler in update.go bumps the index on each tick; renderMessage
+	// reads it when the in-progress assistant message has no chunks yet.
+	// Ignored entirely outside StateStreaming, so the rotator costs
+	// nothing when the TUI is idle.
+	thinkingIdx int
+
 	// AlwaysAllow is invoked when the user picks "always allow" in the
 	// permission modal. The host (TUI launcher) plugs in a function
 	// that persists the pattern to .agents/config.json. May be nil in
@@ -228,6 +236,14 @@ func (m *Model) renderMessage(msg Message) string {
 		// during streaming it falls back to raw text.
 		text := msg.Display()
 		if msg.Rendered == "" {
+			// While streaming hasn't produced any chunks yet, show the
+			// rotating "Thinking…" indicator below the user's prompt
+			// so the wait is visible without scrolling to the footer.
+			// Once the first chunk lands, the indicator gives way to
+			// the actual response text.
+			if m.state == StateStreaming && text == "" {
+				return m.renderThinkingLine()
+			}
 			// Streaming: render raw with the assistant style for color.
 			return m.styles.Assistant.Render(text)
 		}

--- a/internal/tui/thinking.go
+++ b/internal/tui/thinking.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The Cogo Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import "github.com/charmbracelet/lipgloss"
+
+// thinkingTickInterval is how long each cheeky thinking phrase stays
+// on screen before the next one rotates in. Three seconds is long
+// enough to read without effort and short enough that the indicator
+// still feels alive.
+const thinkingTickInterval = 3 * 1000 // milliseconds — see update.go for the tea.Tick wiring
+
+// thinkingPhrases is a curated set of "Thinking…" alternatives shown
+// in the chat window while the model composes a response. The first
+// entry — plain "Thinking…" — anchors the indicator: a fresh turn
+// always starts there so the affordance is unambiguous before the
+// rotator wanders into the AI / sci-fi / CS jokes.
+var thinkingPhrases = []string{
+	"Thinking…",
+	"Consulting the latent space…",
+	"Sampling from the distribution…",
+	"Reticulating splines…",
+	"Computing the answer to the ultimate question…",
+	"Spinning up the attention heads…",
+	"Asking Stack Overflow nicely…",
+	"Untangling pointer chains…",
+	"Bargaining with the loss function…",
+	"Compiling a thoughtful response…",
+	"Defragmenting cache lines…",
+	"Negotiating with the Vogons…",
+	"Brewing a fresh stack frame…",
+	"Plotting a hyperspace course…",
+	"Resolving promises…",
+	"Eval'ing your prompt…",
+}
+
+// thinkingPhrase returns the phrase at idx, wrapping around the slice.
+// Negative inputs are normalized to a positive index. Always returns a
+// non-empty string so the indicator never flickers blank.
+func thinkingPhrase(idx int) string {
+	n := len(thinkingPhrases)
+	if n == 0 {
+		return "Thinking…"
+	}
+	i := idx % n
+	if i < 0 {
+		i += n
+	}
+	return thinkingPhrases[i]
+}
+
+// renderThinkingLine builds the in-chat thinking indicator. It pairs
+// the spinner glyph (already brand-cyan from styles.Spinner via
+// model.go wiring) with the rotating phrase, so the chat indicator
+// reads as the same "system is working" affordance as the footer.
+func (m *Model) renderThinkingLine() string {
+	phrase := thinkingPhrase(m.thinkingIdx)
+	style := lipgloss.NewStyle().Foreground(brandCyan).Italic(true)
+	return m.spinner.View() + " " + style.Render(phrase)
+}

--- a/internal/tui/thinking_test.go
+++ b/internal/tui/thinking_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 The Cogo Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/go-steer/cogo/internal/config"
+)
+
+// TestThinkingPhrase_WrapsAndAnchors pins two contracts at once:
+//
+//   - thinkingPhrase(0) MUST return the anchor phrase ("Thinking…")
+//     so every turn begins with the unambiguous indicator before the
+//     cheeky rotator wanders into the AI / sci-fi / CS jokes. Users
+//     who don't get the joke still see "Thinking…" first.
+//   - thinkingPhrase wraps cleanly past the end of the slice so the
+//     rotator never panics on long-running turns.
+//
+// DO NOT silence this test if it breaks. A regression here either (a)
+// removes the user-friendly anchor, leaving newcomers confused about
+// what "Reticulating splines…" means, or (b) crashes the rotator on a
+// long turn, which is exactly when users most need the indicator.
+func TestThinkingPhrase_WrapsAndAnchors(t *testing.T) {
+	t.Parallel()
+	if got := thinkingPhrase(0); got != "Thinking…" {
+		t.Errorf("thinkingPhrase(0) = %q, want anchor %q", got, "Thinking…")
+	}
+	n := len(thinkingPhrases)
+	if got, want := thinkingPhrase(n), thinkingPhrases[0]; got != want {
+		t.Errorf("thinkingPhrase(n) did not wrap to index 0; got %q want %q", got, want)
+	}
+	if got, want := thinkingPhrase(-1), thinkingPhrases[n-1]; got != want {
+		t.Errorf("thinkingPhrase(-1) did not wrap to last index; got %q want %q", got, want)
+	}
+	if n < 10 {
+		t.Errorf("thinkingPhrases has %d entries; the spec calls for 10-15 so the rotator stays interesting", n)
+	}
+}
+
+// TestRenderMessage_StreamingPlaceholderShowsThinking pins the chat
+// indicator contract: while the assistant placeholder has no text yet
+// AND the model is in StateStreaming, the assistant slot in the chat
+// must render the rotating thinking indicator (not a blank line).
+//
+// DO NOT silence this test if it breaks. A failure means the user
+// sends a prompt and stares at an empty space until the first chunk
+// streams in — the exact "is anything happening?" UX gap this feature
+// closes. If the rendering path legitimately changes, replace the
+// assertion with one that proves the new path still surfaces the
+// indicator below the user's prompt; never delete the contract.
+func TestRenderMessage_StreamingPlaceholderShowsThinking(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultConfig()
+	m := NewModel(cfg, nil, "dark")
+	m.Update(tea.WindowSizeMsg{Width: 100, Height: 24})
+	m.history.Append(Message{Role: RoleUser, Text: "hello"})
+	m.history.Append(Message{Role: RoleAssistant}) // empty placeholder
+	m.currentAssistantIdx = 1
+	m.state = StateStreaming
+	m.thinkingIdx = 0
+	m.refreshViewport()
+
+	// View() output covers header + viewport + input + footer; the
+	// footer ALSO says "Thinking…" in streaming mode, so we can't
+	// just grep the whole frame for that token. Pull the viewport
+	// region directly to assert the chat-window indicator.
+	body := stripANSI(m.viewport.View())
+	if !strings.Contains(body, "Thinking…") {
+		t.Errorf("expected anchor phrase 'Thinking…' in viewport while streaming; got:\n%s", body)
+	}
+
+	// Rotate and verify the next phrase shows up after a refresh.
+	m.thinkingIdx = 1
+	m.refreshViewport()
+	body = stripANSI(m.viewport.View())
+	if !strings.Contains(body, thinkingPhrases[1]) {
+		t.Errorf("expected rotated phrase %q in viewport; got:\n%s", thinkingPhrases[1], body)
+	}
+
+	// Once a chunk lands, the indicator must give way to the response.
+	m.history.AppendText(1, "actual response text")
+	m.refreshViewport()
+	body = stripANSI(m.viewport.View())
+	if strings.Contains(body, "Thinking…") || strings.Contains(body, thinkingPhrases[1]) {
+		t.Errorf("thinking indicator should be hidden once the assistant message has content; got:\n%s", body)
+	}
+	if !strings.Contains(body, "actual response text") {
+		t.Errorf("response text should be visible after first chunk; got:\n%s", body)
+	}
+}
+
+// TestRenderMessage_IdleAssistantNoThinking guards against the inverse
+// regression: when the agent is idle (e.g. a stale assistant message
+// whose render somehow gets re-evaluated), the thinking indicator must
+// NOT appear. Otherwise users see "Thinking…" forever after a turn
+// finishes — worse than no indicator at all.
+func TestRenderMessage_IdleAssistantNoThinking(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultConfig()
+	m := NewModel(cfg, nil, "dark")
+	m.Update(tea.WindowSizeMsg{Width: 100, Height: 24})
+	m.history.Append(Message{Role: RoleUser, Text: "hi"})
+	m.history.Append(Message{Role: RoleAssistant}) // empty assistant
+	m.state = StateIdle                            // not streaming
+	m.refreshViewport()
+
+	body := stripANSI(m.viewport.View())
+	if strings.Contains(body, "Thinking…") {
+		t.Errorf("thinking indicator should NOT appear in chat while idle; got:\n%s", body)
+	}
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
@@ -17,6 +18,20 @@ import (
 	"github.com/go-steer/cogo/internal/permissions"
 	"github.com/go-steer/cogo/internal/usage"
 )
+
+// thinkingTickMsg fires on a timer while a turn is in flight so the
+// in-chat "Thinking…" indicator can rotate to the next phrase. The
+// scheduler reschedules itself only while StateStreaming, so no
+// background CPU is spent when the TUI is idle.
+type thinkingTickMsg struct{}
+
+// thinkingTickCmd returns a tea.Cmd that emits a thinkingTickMsg after
+// thinkingTickInterval milliseconds.
+func thinkingTickCmd() tea.Cmd {
+	return tea.Tick(time.Duration(thinkingTickInterval)*time.Millisecond, func(time.Time) tea.Msg {
+		return thinkingTickMsg{}
+	})
+}
 
 // Update is Cogo's central message dispatch.
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -108,6 +123,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
 		return m, cmd
+	case thinkingTickMsg:
+		// Drop the tick if the turn finished mid-flight. Otherwise
+		// rotate to the next phrase, redraw, and reschedule.
+		if m.state != StateStreaming {
+			return m, nil
+		}
+		m.thinkingIdx++
+		m.refreshViewport()
+		return m, thinkingTickCmd()
 	}
 	// Unhandled — forward typing/etc. to the textarea.
 	var cmd tea.Cmd
@@ -589,13 +613,16 @@ func (m *Model) handleSubmit() (tea.Model, tea.Cmd) {
 	idx := m.history.Append(Message{Role: RoleAssistant})
 	m.currentAssistantIdx = idx
 	m.state = StateStreaming
+	// Reset the thinking-phrase rotator so every turn starts on the
+	// anchor phrase ("Thinking…") and the cycle is predictable.
+	m.thinkingIdx = 0
 
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancelTurn = cancel
 	startAgentTurn(ctx, m.program, m.agent, expanded)
 
 	m.refreshViewport()
-	return m, m.spinner.Tick
+	return m, tea.Batch(m.spinner.Tick, thinkingTickCmd())
 }
 
 func (m *Model) handleSlash(action SlashAction, cmd, args string) (tea.Model, tea.Cmd) {


### PR DESCRIPTION
feat(tui): in-chat rotating "Thinking…" indicator

While the model composes a response there's now a visible affordance
in the chat window itself, right below the user's prompt, instead of
relying on the small footer-only "Thinking… (Ctrl+C to cancel)" hint
that's easy to miss when the eye is parked mid-screen.

Behaviour:

- Every turn starts on the anchor phrase ("Thinking…") so the
  affordance is unambiguous before the rotator wanders off.
- A tea.Tick scheduler rotates to the next entry of thinkingPhrases
  every 3s while StateStreaming, then drops itself the moment the
  turn ends — no background CPU when idle.
- As soon as the first chunk arrives, the indicator gives way to the
  actual response text. The footer "Thinking…" line stays put and
  unchanged, so users who learned the old affordance aren't
  surprised.

The phrase pool is 16 entries spanning AI/ML, sci-fi, and CS humor:
"Reticulating splines…", "Computing the answer to the ultimate
question…", "Untangling pointer chains…", "Negotiating with the
Vogons…", etc. Edit thinkingPhrases in thinking.go to tune.

Tests pin three contracts under "do not silence this test" comments
in thinking_test.go: the rotator wraps cleanly past the slice end
and starts on the anchor phrase; the chat indicator shows in the
viewport while StateStreaming with an empty assistant placeholder
and disappears once the first chunk lands; the indicator does NOT
appear when the model is idle (guards against a stale render
showing "Thinking…" forever).