### PR TITLE
fix(tui): wrap long chat messages at viewport width

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/exp/teatest v0.0.0-20260430013151-79116d1f37bd
 	github.com/modelcontextprotocol/go-sdk v1.4.1
+	github.com/muesli/reflow v0.3.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	golang.org/x/term v0.41.0
@@ -59,7 +60,6 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect

--- a/internal/tui/branding.go
+++ b/internal/tui/branding.go
@@ -7,32 +7,34 @@ import "github.com/charmbracelet/lipgloss"
 
 // Brand colors. Fixed hex (not AdaptiveColor) because the wordmark is
 // brand identity and shouldn't shift between light/dark terminals.
-// brandEye (deep cyan for the inner 'o') and brandGreen (highlight
-// for "go" / cursor block) were retired with the brand-header
-// simplification — see headerBrand for context.
 var (
 	brandCyan  = lipgloss.Color("#00FFFF")
+	brandEye   = lipgloss.Color("#00CED1") // deeper cyan for the inner 'o'
+	brandGreen = lipgloss.Color("#A7FF00")
 	brandSlate = lipgloss.Color("#6272A4")
 )
 
 // headerBrand renders the persistent brand line shown on the left of
-// the status header: `go-steer / c[o]go █`.
+// the status header: `go-steer / c[o]go █`. The headline is short
+// enough to fit on the same row as the status info on any reasonable
+// terminal width, so we don't waste a viewport row on a separate
+// banner.
 //
-// Originally this rendered each colored slice as its own lipgloss
-// span (slate "go-steer / ", bold-cyan "c", "[", deep-cyan "o",
-// bold-cyan "]", green "go", green "█"). That produced ~7 SGR
-// open/close pairs per render — fine on most terminals but reported
-// to correlate with rendering glitches on the user's VS Code host
-// (random capital letters disappearing, traced to malformed CSI
-// sequences). Collapsing to two styled spans (slate prefix + bold-
-// cyan brand mark) cuts the SGR density without losing the wordmark.
-// We trade the green "go" / deep-cyan inner "o" highlights for
-// stability; that's a worthwhile swap until the host renderer is
-// happier with denser ANSI.
+// Each colored slice is its own lipgloss span. We tried collapsing to
+// a single bold-cyan span over "c[o]go █" as a mitigation for an
+// unrelated "missing characters" report, and that made the brand
+// itself drop characters on the user's host — the dense per-letter
+// styling actually renders correctly there, the simplified single-
+// span did not. Keep the multi-span layout; the missing-chars issue
+// is something else entirely.
 func headerBrand() string {
-	prefix := lipgloss.NewStyle().Foreground(brandSlate).Render("go-steer / ")
-	mark := lipgloss.NewStyle().Foreground(brandCyan).Bold(true).Render("c[o]go █")
-	return prefix + mark
+	bracket := lipgloss.NewStyle().Foreground(brandCyan).Bold(true)
+	c := lipgloss.NewStyle().Foreground(brandCyan).Bold(true).Render("c")
+	o := lipgloss.NewStyle().Foreground(brandEye).Bold(true).Render("o")
+	g := lipgloss.NewStyle().Foreground(brandGreen).Render("go")
+	cursor := lipgloss.NewStyle().Foreground(brandGreen).Bold(true).Render("█")
+	org := lipgloss.NewStyle().Foreground(brandSlate).Render("go-steer / ")
+	return org + c + bracket.Render("[") + o + bracket.Render("]") + g + " " + cursor
 }
 
 // emptyStateHint is shown inside the viewport when the chat history is

--- a/internal/tui/branding.go
+++ b/internal/tui/branding.go
@@ -7,33 +7,32 @@ import "github.com/charmbracelet/lipgloss"
 
 // Brand colors. Fixed hex (not AdaptiveColor) because the wordmark is
 // brand identity and shouldn't shift between light/dark terminals.
+// brandEye (deep cyan for the inner 'o') and brandGreen (highlight
+// for "go" / cursor block) were retired with the brand-header
+// simplification — see headerBrand for context.
 var (
 	brandCyan  = lipgloss.Color("#00FFFF")
-	brandEye   = lipgloss.Color("#00CED1") // deeper cyan for the inner 'o'
-	brandGreen = lipgloss.Color("#A7FF00")
 	brandSlate = lipgloss.Color("#6272A4")
 )
 
 // headerBrand renders the persistent brand line shown on the left of
-// the status header: `go-steer / c[o]go █`. The headline is short
-// enough to fit on the same row as the status info on any reasonable
-// terminal width, so we don't waste a viewport row on a separate
-// banner.
+// the status header: `go-steer / c[o]go █`.
 //
-// The trailing block is rendered as a `█` glyph in green rather than a
-// space with a green background + padding. Background + padding plays
-// poorly with some terminals and lipgloss layout (occasional wrapping
-// or the whole header collapsing when JoinHorizontal disagrees with
-// the outer Padding). The glyph approach is one column wide, has no
-// background to mismatch, and renders identically everywhere.
+// Originally this rendered each colored slice as its own lipgloss
+// span (slate "go-steer / ", bold-cyan "c", "[", deep-cyan "o",
+// bold-cyan "]", green "go", green "█"). That produced ~7 SGR
+// open/close pairs per render — fine on most terminals but reported
+// to correlate with rendering glitches on the user's VS Code host
+// (random capital letters disappearing, traced to malformed CSI
+// sequences). Collapsing to two styled spans (slate prefix + bold-
+// cyan brand mark) cuts the SGR density without losing the wordmark.
+// We trade the green "go" / deep-cyan inner "o" highlights for
+// stability; that's a worthwhile swap until the host renderer is
+// happier with denser ANSI.
 func headerBrand() string {
-	bracket := lipgloss.NewStyle().Foreground(brandCyan).Bold(true)
-	c := lipgloss.NewStyle().Foreground(brandCyan).Bold(true).Render("c")
-	o := lipgloss.NewStyle().Foreground(brandEye).Bold(true).Render("o")
-	g := lipgloss.NewStyle().Foreground(brandGreen).Render("go")
-	cursor := lipgloss.NewStyle().Foreground(brandGreen).Bold(true).Render("█")
-	org := lipgloss.NewStyle().Foreground(brandSlate).Render("go-steer / ")
-	return org + c + bracket.Render("[") + o + bracket.Render("]") + g + " " + cursor
+	prefix := lipgloss.NewStyle().Foreground(brandSlate).Render("go-steer / ")
+	mark := lipgloss.NewStyle().Foreground(brandCyan).Bold(true).Render("c[o]go █")
+	return prefix + mark
 }
 
 // emptyStateHint is shown inside the viewport when the chat history is

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -14,6 +14,7 @@ import (
 	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/muesli/reflow/wordwrap"
 
 	"github.com/go-steer/cogo/internal/agent"
 	"github.com/go-steer/cogo/internal/config"
@@ -230,7 +231,11 @@ func (m *Model) renderMessage(msg Message) string {
 	switch msg.Role {
 	case RoleUser:
 		prefix := m.styles.UserPrefix.Render("❯")
-		return prefix + " " + m.styles.UserText.Render(msg.Display())
+		// Wrap the prompt at the viewport width so long messages
+		// don't run off the right edge. Continuation lines are
+		// indented to align with the text after the "❯ " prefix.
+		wrapped := wrapForChat(msg.Display(), m.viewport.Width-2, "  ")
+		return prefix + " " + m.styles.UserText.Render(wrapped)
 	case RoleAssistant:
 		// Display() prefers the Glamour-rendered form when available;
 		// during streaming it falls back to raw text.
@@ -244,8 +249,10 @@ func (m *Model) renderMessage(msg Message) string {
 			if m.state == StateStreaming && text == "" {
 				return m.renderThinkingLine()
 			}
-			// Streaming: render raw with the assistant style for color.
-			return m.styles.Assistant.Render(text)
+			// Streaming: wrap raw text at viewport width so long
+			// chunks don't overflow before Glamour gets to re-render
+			// the finalized message.
+			return m.styles.Assistant.Render(wrapForChat(text, m.viewport.Width, ""))
 		}
 		// Append a per-prompt usage footer when available.
 		if footer := m.lastTurnUsageFooter(); footer != "" {
@@ -253,12 +260,32 @@ func (m *Model) renderMessage(msg Message) string {
 		}
 		return text
 	case RoleSystem:
-		return m.styles.System.Render("ℹ  " + msg.Display())
+		return m.styles.System.Render(wrapForChat("ℹ  "+msg.Display(), m.viewport.Width, "   "))
 	case RoleError:
-		return m.styles.Error.Render("⚠  " + msg.Display())
+		return m.styles.Error.Render(wrapForChat("⚠  "+msg.Display(), m.viewport.Width, "   "))
 	default:
 		return msg.Display()
 	}
+}
+
+// wrapForChat word-wraps text to fit inside a chat line of the given
+// visible width. Continuation lines are prefixed with `indent` so they
+// align past the role's leading glyph (e.g. "❯ " -> indent "  "). When
+// width <= 0 (pre-resize) the original text is returned untouched so
+// callers don't have to special-case the boot path.
+func wrapForChat(text string, width int, indent string) string {
+	if width <= 0 {
+		return text
+	}
+	wrapped := wordwrap.String(text, width)
+	if indent == "" {
+		return wrapped
+	}
+	lines := strings.Split(wrapped, "\n")
+	for i := 1; i < len(lines); i++ {
+		lines[i] = indent + lines[i]
+	}
+	return strings.Join(lines, "\n")
 }
 
 // lastTurnUsageFooter renders the most recent turn's usage as a small

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/muesli/reflow/wordwrap"
+	"github.com/muesli/reflow/wrap"
 
 	"github.com/go-steer/cogo/internal/agent"
 	"github.com/go-steer/cogo/internal/config"
@@ -273,11 +274,17 @@ func (m *Model) renderMessage(msg Message) string {
 // align past the role's leading glyph (e.g. "❯ " -> indent "  "). When
 // width <= 0 (pre-resize) the original text is returned untouched so
 // callers don't have to special-case the boot path.
+//
+// muesli/reflow's wordwrap respects word boundaries and never breaks a
+// single mega-word — a long URL or token would still overflow. Chain
+// it with reflow's wrap (force-break at column) so the over-long
+// fragments left by wordwrap also get split. wordwrap first to
+// preserve word boundaries where possible; wrap second to mop up.
 func wrapForChat(text string, width int, indent string) string {
 	if width <= 0 {
 		return text
 	}
-	wrapped := wordwrap.String(text, width)
+	wrapped := wrap.String(wordwrap.String(text, width), width)
 	if indent == "" {
 		return wrapped
 	}

--- a/internal/tui/wrap_test.go
+++ b/internal/tui/wrap_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The Cogo Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/go-steer/cogo/internal/config"
+)
+
+// TestWrapForChat covers the wrapping helper directly: width gates,
+// indentation applied to continuation lines only, and the no-op path
+// for pre-resize callers.
+func TestWrapForChat(t *testing.T) {
+	t.Parallel()
+	long := "the quick brown fox jumps over the lazy dog every single morning"
+	got := wrapForChat(long, 20, "  ")
+	lines := strings.Split(got, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected wrapping at width 20; got 1 line: %q", got)
+	}
+	for i, ln := range lines {
+		visible := len(ln)
+		if i > 0 {
+			if !strings.HasPrefix(ln, "  ") {
+				t.Errorf("continuation line %d missing indent: %q", i, ln)
+			}
+			// strip indent for width check
+			visible -= 2
+		}
+		if visible > 20 {
+			t.Errorf("line %d exceeds width 20 (%d chars): %q", i, visible, ln)
+		}
+	}
+
+	// width <= 0 short-circuits to original text (pre-resize path).
+	if got := wrapForChat("anything", 0, "  "); got != "anything" {
+		t.Errorf("width=0 should return text untouched; got %q", got)
+	}
+	if got := wrapForChat("anything", -1, "  "); got != "anything" {
+		t.Errorf("width<0 should return text untouched; got %q", got)
+	}
+}
+
+// TestRenderMessage_LongUserPromptWraps pins the user-visible bug:
+// long prompts must wrap inside the chat viewport instead of running
+// off the right edge. Failure mode: user types a paragraph, sends it,
+// and only the first ~viewport-width characters are visible while the
+// rest disappears past the screen edge.
+//
+// DO NOT silence this test. The wrap is the whole point.
+func TestRenderMessage_LongUserPromptWraps(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultConfig()
+	m := NewModel(cfg, nil, "dark")
+	m.Update(tea.WindowSizeMsg{Width: 60, Height: 24})
+
+	long := "this is a moderately long prompt that absolutely must wrap inside the chat viewport otherwise users see only a slice of it"
+	m.history.Append(Message{Role: RoleUser, Text: long})
+	m.refreshViewport()
+	body := stripANSI(m.viewport.View())
+	lines := strings.Split(body, "\n")
+
+	// At least two non-empty lines should contain prompt content.
+	hits := 0
+	for _, ln := range lines {
+		ln = strings.TrimSpace(ln)
+		if ln == "" {
+			continue
+		}
+		if strings.Contains(ln, "wrap") || strings.Contains(ln, "viewport") || strings.Contains(ln, "moderately") {
+			hits++
+		}
+	}
+	if hits < 2 {
+		t.Errorf("long prompt did not wrap across multiple chat rows; only %d row(s) contained prompt fragments.\nbody:\n%s", hits, body)
+	}
+}


### PR DESCRIPTION
fix(tui): wrap long chat messages at viewport width

Long user prompts (and long system / error / pre-Glamour streaming
chunks) ran off the right edge of the chat viewport and disappeared
past the screen. The viewport itself doesn't auto-wrap content; we
were handing it single-line styled strings, however long.

Add a `wrapForChat(text, width, indent)` helper backed by
muesli/reflow's `wordwrap.String`, and route every per-role render
path through it:

- User prompts wrap at viewport.Width-2 with continuation lines
  indented two spaces so they align past the "❯ " prefix.
- System (`ℹ  …`) and error (`⚠  …`) wraps at viewport.Width with
  three-space continuation indent (one icon + two spaces).
- Streaming-assistant raw text wraps at viewport.Width while we wait
  for Glamour to take over after the turn finishes.

`width <= 0` short-circuits to the original text so the pre-resize
boot path doesn't crash. Glamour-rendered (post-stream) assistant
text is left untouched — Glamour already word-wraps it.

Tests:

- TestWrapForChat covers the helper directly: continuation lines stay
  within the width budget, the indent is applied to lines >= 1 only,
  and width <= 0 is a no-op.
- TestRenderMessage_LongUserPromptWraps pins the user-visible bug:
  a long prompt must produce >= 2 chat rows containing prompt
  fragments. Carries the project's "do not silence this test"
  convention so future renderers can't quietly regress the wrap.

Promoted muesli/reflow from indirect to direct dep in go.mod.