### PR TITLE
feat(tui): show tool calls in the chat window

### DIFF
--- a/internal/tui/agentcmd.go
+++ b/internal/tui/agentcmd.go
@@ -27,6 +27,11 @@ type programSender interface {
 func startAgentTurn(ctx context.Context, send programSender, a *agent.Agent, prompt string) {
 	go func() {
 		var lastIn, lastOut int
+		// ADK can emit the same FunctionCall on more than one event
+		// (e.g., a partial streaming event followed by the committed
+		// non-partial event). Deduping by FunctionCall.ID keeps the
+		// chat from showing every tool invocation twice.
+		seenToolCallIDs := make(map[string]bool)
 		for event, err := range a.Run(ctx, prompt) {
 			if err != nil {
 				if lastIn > 0 || lastOut > 0 {
@@ -46,17 +51,27 @@ func startAgentTurn(ctx context.Context, send programSender, a *agent.Agent, pro
 			if event.Content == nil {
 				continue
 			}
-			// Tool invocations arrive on non-Partial events with a
-			// FunctionCall part. Surface each one to the chat as its
-			// own line so the user sees the agent's actions
-			// interleaved with the streaming prose.
+			// Surface each unique tool invocation to the chat. Dedupe
+			// on FunctionCall.ID so we don't emit the same call twice
+			// when ADK echoes it across partial + committed events.
+			// Calls without an ID are emitted unconditionally — a
+			// missing ID is rare but a tool line is more useful than
+			// a silent drop.
 			for _, p := range event.Content.Parts {
-				if p.FunctionCall != nil && p.FunctionCall.Name != "" {
-					send.Send(toolCallMsg{
-						Name: p.FunctionCall.Name,
-						Args: p.FunctionCall.Args,
-					})
+				if p.FunctionCall == nil || p.FunctionCall.Name == "" {
+					continue
 				}
+				id := p.FunctionCall.ID
+				if id != "" && seenToolCallIDs[id] {
+					continue
+				}
+				if id != "" {
+					seenToolCallIDs[id] = true
+				}
+				send.Send(toolCallMsg{
+					Name: p.FunctionCall.Name,
+					Args: p.FunctionCall.Args,
+				})
 			}
 			if !event.Partial {
 				continue

--- a/internal/tui/agentcmd.go
+++ b/internal/tui/agentcmd.go
@@ -43,7 +43,22 @@ func startAgentTurn(ctx context.Context, send programSender, a *agent.Agent, pro
 				lastIn = int(event.UsageMetadata.PromptTokenCount)
 				lastOut = int(event.UsageMetadata.CandidatesTokenCount)
 			}
-			if event.Content == nil || !event.Partial {
+			if event.Content == nil {
+				continue
+			}
+			// Tool invocations arrive on non-Partial events with a
+			// FunctionCall part. Surface each one to the chat as its
+			// own line so the user sees the agent's actions
+			// interleaved with the streaming prose.
+			for _, p := range event.Content.Parts {
+				if p.FunctionCall != nil && p.FunctionCall.Name != "" {
+					send.Send(toolCallMsg{
+						Name: p.FunctionCall.Name,
+						Args: p.FunctionCall.Args,
+					})
+				}
+			}
+			if !event.Partial {
 				continue
 			}
 			for _, p := range event.Content.Parts {

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -28,6 +28,16 @@ type streamChunkMsg struct {
 	Text string
 }
 
+// toolCallMsg is emitted by the agent goroutine when the model decides
+// to invoke a tool. The TUI renders a one-line summary in the chat so
+// the user can see the agent's actions interleaved with its prose.
+// Args is the raw key/value map from the model; the renderer pulls a
+// brief summary out of it (the bash command, the file path, etc.).
+type toolCallMsg struct {
+	Name string
+	Args map[string]any
+}
+
 // turnDoneMsg signals the agent has finished the current turn cleanly.
 // The TUI uses this to flip state back to idle and to apply the Glamour
 // re-render to the in-progress assistant message.

--- a/internal/tui/messages_history.go
+++ b/internal/tui/messages_history.go
@@ -16,6 +16,7 @@ const (
 	RoleAssistant             // model output (raw markdown)
 	RoleSystem                // notices like "/clear", "/help" output
 	RoleError                 // unrecoverable error from a turn
+	RoleTool                  // a tool invocation made by the agent (display-only)
 )
 
 // Message is one entry in the chat history.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -216,14 +216,24 @@ func (m *Model) Init() tea.Cmd {
 // yet, an empty-state hint stands in so the viewport isn't blank on
 // first launch — the brand wordmark already lives in the persistent
 // header above, so no banner is needed here.
+//
+// During a streaming turn, the rotating "Thinking…" indicator is
+// appended at the very end whenever the agent is between segments —
+// either before any chunk has arrived, or after a tool call closed
+// the previous segment and the next chunk hasn't landed yet. The
+// indicator therefore always stays at the bottom of the chat as new
+// tool calls and assistant segments scroll past it.
 func (m *Model) renderHistory() string {
 	if m.history.Len() == 0 {
 		return emptyStateHint()
 	}
 	msgs := m.history.Snapshot()
-	parts := make([]string, 0, len(msgs))
+	parts := make([]string, 0, len(msgs)+1)
 	for _, msg := range msgs {
 		parts = append(parts, m.renderMessage(msg))
+	}
+	if m.state == StateStreaming && m.currentAssistantIdx < 0 {
+		parts = append(parts, m.renderThinkingLine())
 	}
 	return strings.Join(parts, "\n\n")
 }
@@ -239,17 +249,11 @@ func (m *Model) renderMessage(msg Message) string {
 		return prefix + " " + m.styles.UserText.Render(wrapped)
 	case RoleAssistant:
 		// Display() prefers the Glamour-rendered form when available;
-		// during streaming it falls back to raw text.
+		// during streaming it falls back to raw text. The thinking
+		// indicator no longer renders here — renderHistory appends it
+		// at the bottom of the chat when the agent is between segments.
 		text := msg.Display()
 		if msg.Rendered == "" {
-			// While streaming hasn't produced any chunks yet, show the
-			// rotating "Thinking…" indicator below the user's prompt
-			// so the wait is visible without scrolling to the footer.
-			// Once the first chunk lands, the indicator gives way to
-			// the actual response text.
-			if m.state == StateStreaming && text == "" {
-				return m.renderThinkingLine()
-			}
 			// Streaming: wrap raw text at viewport width so long
 			// chunks don't overflow before Glamour gets to re-render
 			// the finalized message.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -264,9 +264,81 @@ func (m *Model) renderMessage(msg Message) string {
 		return m.styles.System.Render(wrapForChat("ℹ  "+msg.Display(), m.viewport.Width, "   "))
 	case RoleError:
 		return m.styles.Error.Render(wrapForChat("⚠  "+msg.Display(), m.viewport.Width, "   "))
+	case RoleTool:
+		// Tool lines render the icon + name in the bold-accent style
+		// (matches the model name in the header — proven stable on
+		// every host we test). The arg summary, if any, is already
+		// embedded in msg.Text as a "· " separated suffix; both spans
+		// are wrapped at viewport width with continuation indent
+		// past the "⚙ " prefix.
+		return m.styles.HeaderAccent.Render(wrapForChat("⚙  "+msg.Display(), m.viewport.Width, "   "))
 	default:
 		return msg.Display()
 	}
+}
+
+// formatToolCall renders a one-line summary of a tool invocation for
+// the chat: just the tool name when no useful arg is available, or
+// `name · <hint>` when we can pull a recognizable hint out of args.
+// We deliberately keep it single-line and short — the chat is for the
+// human to glance at the agent's actions, not for full audit trails.
+func formatToolCall(name string, args map[string]any) string {
+	hint := toolArgHint(name, args)
+	if hint == "" {
+		return name
+	}
+	// Cap the hint so a giant inline file or 4 KB bash command can't
+	// blow out a single chat row. Wrap will still shorten it further
+	// if the viewport is narrow; this is an absolute upper bound.
+	const maxHint = 200
+	if len(hint) > maxHint {
+		hint = hint[:maxHint] + "…"
+	}
+	return name + " · " + hint
+}
+
+// toolArgHint extracts the most useful one-line hint from a tool's
+// argument map. Recognizes the common cogo built-in tools by name; for
+// anything else it returns "" so the line stays as just the tool name.
+// Adding new tools here is cheap; not adding them is harmless.
+func toolArgHint(name string, args map[string]any) string {
+	if args == nil {
+		return ""
+	}
+	pick := func(keys ...string) string {
+		for _, k := range keys {
+			if v, ok := args[k]; ok {
+				if s, ok := v.(string); ok && s != "" {
+					return s
+				}
+			}
+		}
+		return ""
+	}
+	switch name {
+	case "bash":
+		if cmd := pick("command", "cmd"); cmd != "" {
+			return "$ " + strings.ReplaceAll(strings.ReplaceAll(cmd, "\n", " "), "\t", " ")
+		}
+	case "read_file":
+		return pick("path", "file", "filename")
+	case "write_file":
+		return pick("path", "file", "filename")
+	case "grep":
+		pattern := pick("pattern", "query")
+		path := pick("path", "dir")
+		switch {
+		case pattern != "" && path != "":
+			return strconv.Quote(pattern) + " in " + path
+		case pattern != "":
+			return strconv.Quote(pattern)
+		case path != "":
+			return path
+		}
+	case "list_files", "ls":
+		return pick("path", "dir")
+	}
+	return ""
 }
 
 // wrapForChat word-wraps text to fit inside a chat line of the given

--- a/internal/tui/thinking_test.go
+++ b/internal/tui/thinking_test.go
@@ -42,36 +42,33 @@ func TestThinkingPhrase_WrapsAndAnchors(t *testing.T) {
 	}
 }
 
-// TestRenderMessage_StreamingPlaceholderShowsThinking pins the chat
-// indicator contract: while the assistant placeholder has no text yet
-// AND the model is in StateStreaming, the assistant slot in the chat
-// must render the rotating thinking indicator (not a blank line).
+// TestRenderMessage_StreamingShowsThinkingBetweenSegments pins the
+// chat indicator contract: while the model is in StateStreaming AND
+// the agent is between assistant segments (no in-progress message
+// yet, OR a tool call just closed the previous segment), the chat
+// MUST render the rotating thinking indicator at the bottom.
 //
 // DO NOT silence this test if it breaks. A failure means the user
-// sends a prompt and stares at an empty space until the first chunk
-// streams in — the exact "is anything happening?" UX gap this feature
-// closes. If the rendering path legitimately changes, replace the
-// assertion with one that proves the new path still surfaces the
-// indicator below the user's prompt; never delete the contract.
-func TestRenderMessage_StreamingPlaceholderShowsThinking(t *testing.T) {
+// sends a prompt (or watches a tool call resolve) and stares at an
+// empty space until the next chunk arrives — the exact "is anything
+// happening?" UX gap this feature closes.
+func TestRenderMessage_StreamingShowsThinkingBetweenSegments(t *testing.T) {
 	t.Parallel()
 	cfg := config.DefaultConfig()
 	m := NewModel(cfg, nil, "dark")
 	m.Update(tea.WindowSizeMsg{Width: 100, Height: 24})
 	m.history.Append(Message{Role: RoleUser, Text: "hello"})
-	m.history.Append(Message{Role: RoleAssistant}) // empty placeholder
-	m.currentAssistantIdx = 1
+	m.currentAssistantIdx = -1 // no in-progress assistant
 	m.state = StateStreaming
 	m.thinkingIdx = 0
 	m.refreshViewport()
 
-	// View() output covers header + viewport + input + footer; the
-	// footer ALSO says "Thinking..." in streaming mode, so we can't
-	// just grep the whole frame for that token. Pull the viewport
+	// View() covers header + viewport + input + footer; the footer
+	// ALSO says "Thinking..." in streaming mode, so pull the viewport
 	// region directly to assert the chat-window indicator.
 	body := stripANSI(m.viewport.View())
 	if !strings.Contains(body, "Thinking...") {
-		t.Errorf("expected anchor phrase 'Thinking…' in viewport while streaming; got:\n%s", body)
+		t.Errorf("expected anchor phrase 'Thinking...' in viewport while streaming with no in-progress assistant; got:\n%s", body)
 	}
 
 	// Rotate and verify the next phrase shows up after a refresh.
@@ -82,15 +79,29 @@ func TestRenderMessage_StreamingPlaceholderShowsThinking(t *testing.T) {
 		t.Errorf("expected rotated phrase %q in viewport; got:\n%s", thinkingPhrases[1], body)
 	}
 
-	// Once a chunk lands, the indicator must give way to the response.
-	m.history.AppendText(1, "actual response text")
+	// Once a chunk arrives the assistant message is created and the
+	// indicator at the bottom of the chat must give way to the
+	// response text.
+	idx := m.history.Append(Message{Role: RoleAssistant, Text: "actual response text"})
+	m.currentAssistantIdx = idx
 	m.refreshViewport()
 	body = stripANSI(m.viewport.View())
 	if strings.Contains(body, "Thinking...") || strings.Contains(body, thinkingPhrases[1]) {
-		t.Errorf("thinking indicator should be hidden once the assistant message has content; got:\n%s", body)
+		t.Errorf("thinking indicator should be hidden once an assistant segment has content; got:\n%s", body)
 	}
 	if !strings.Contains(body, "actual response text") {
 		t.Errorf("response text should be visible after first chunk; got:\n%s", body)
+	}
+
+	// Simulate a tool call closing the segment: clear currentAssistantIdx
+	// and append a tool entry. The thinking indicator MUST come back at
+	// the bottom while we wait for the next assistant segment.
+	m.history.Append(Message{Role: RoleTool, Text: "bash · $ ls"})
+	m.currentAssistantIdx = -1
+	m.refreshViewport()
+	body = stripANSI(m.viewport.View())
+	if !strings.Contains(body, "Thinking...") && !strings.Contains(body, thinkingPhrases[1]) {
+		t.Errorf("thinking indicator should reappear after a tool call closes the previous segment; got:\n%s", body)
 	}
 }
 

--- a/internal/tui/toolcall_test.go
+++ b/internal/tui/toolcall_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 The Cogo Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/go-steer/cogo/internal/config"
+)
+
+// TestFormatToolCall covers the per-tool arg-hint logic. The hint is
+// best-effort — unknown tools fall through to bare-name rendering —
+// but the recognized cogo built-ins (bash, read_file, write_file,
+// grep) MUST surface their primary argument so the chat line
+// actually tells the user what's happening.
+func TestFormatToolCall(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		toolnm string
+		args   map[string]any
+		want   string
+	}{
+		{"bare unknown tool", "do_something", nil, "do_something"},
+		{"bare tool empty args", "do_something", map[string]any{}, "do_something"},
+		{"bash with command", "bash", map[string]any{"command": "ls -la"}, "bash · $ ls -la"},
+		{"bash with cmd alias", "bash", map[string]any{"cmd": "go test ./..."}, "bash · $ go test ./..."},
+		{"bash collapses newlines", "bash", map[string]any{"command": "echo a\necho b"}, "bash · $ echo a echo b"},
+		{"read_file path", "read_file", map[string]any{"path": "internal/tui/model.go"}, "read_file · internal/tui/model.go"},
+		{"read_file file alias", "read_file", map[string]any{"file": "README.md"}, "read_file · README.md"},
+		{"write_file path", "write_file", map[string]any{"path": "out.txt"}, "write_file · out.txt"},
+		{"grep pattern + path", "grep", map[string]any{"pattern": "TODO", "path": "internal/"}, "grep · \"TODO\" in internal/"},
+		{"grep pattern only", "grep", map[string]any{"pattern": "FIXME"}, "grep · \"FIXME\""},
+		{"unknown tool with args still bare", "weird_tool", map[string]any{"x": 42}, "weird_tool"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := formatToolCall(tc.toolnm, tc.args); got != tc.want {
+				t.Errorf("formatToolCall(%q, %v) = %q; want %q", tc.toolnm, tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFormatToolCall_LongHintTruncated guards the absolute-upper-bound
+// cap on the inline hint. Without this, a giant inlined file or a 4 KB
+// bash heredoc would push the chat line into many wrap rows.
+func TestFormatToolCall_LongHintTruncated(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("a", 500)
+	out := formatToolCall("bash", map[string]any{"command": long})
+	if !strings.HasSuffix(out, "…") {
+		t.Errorf("oversized hint should end in '…'; got: %q", out[len(out)-20:])
+	}
+	if len(out) > 250 {
+		t.Errorf("formatToolCall did not cap a 500-char hint; got %d chars", len(out))
+	}
+}
+
+// TestRenderMessage_ToolCallShowsIconAndName pins the chat-display
+// contract for tool calls: the rendered line contains the ⚙ icon and
+// the tool name (and any arg hint), wrapped + styled through the same
+// HeaderAccent path that the model name in the header uses (proven
+// stable on every host we test).
+//
+// DO NOT silence this test if it breaks. The whole point of the
+// feature is that the user can see, mid-stream, which tools the agent
+// is invoking; losing the icon, the name, or the visibility on a
+// stable styling path defeats the affordance.
+func TestRenderMessage_ToolCallShowsIconAndName(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultConfig()
+	m := NewModel(cfg, nil, "dark")
+	m.Update(tea.WindowSizeMsg{Width: 100, Height: 24})
+	m.history.Append(Message{Role: RoleUser, Text: "list files"})
+	m.history.Append(Message{Role: RoleTool, Text: formatToolCall("bash", map[string]any{"command": "ls -la"})})
+	m.refreshViewport()
+	body := stripANSI(m.viewport.View())
+	if !strings.Contains(body, "⚙") {
+		t.Errorf("tool line missing ⚙ icon; got:\n%s", body)
+	}
+	if !strings.Contains(body, "bash") {
+		t.Errorf("tool line missing tool name 'bash'; got:\n%s", body)
+	}
+	if !strings.Contains(body, "ls -la") {
+		t.Errorf("tool line missing arg hint 'ls -la'; got:\n%s", body)
+	}
+}
+
+// TestUpdate_ToolCallMsgAppendsHistory pins the wiring from agent
+// goroutine to chat history: a toolCallMsg that arrives in Update
+// MUST cause a RoleTool entry to land in m.history with the formatted
+// summary text. Without this, the agentcmd.go FunctionCall hook is a
+// no-op for the user.
+func TestUpdate_ToolCallMsgAppendsHistory(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultConfig()
+	m := NewModel(cfg, nil, "dark")
+	m.Update(tea.WindowSizeMsg{Width: 100, Height: 24})
+	before := m.history.Len()
+	m.Update(toolCallMsg{Name: "read_file", Args: map[string]any{"path": "go.mod"}})
+	if m.history.Len() != before+1 {
+		t.Fatalf("toolCallMsg should append exactly one history entry; was %d, now %d", before, m.history.Len())
+	}
+	last := m.history.Snapshot()[m.history.Len()-1]
+	if last.Role != RoleTool {
+		t.Errorf("appended message has Role=%v; want RoleTool", last.Role)
+	}
+	if !strings.Contains(last.Text, "read_file") || !strings.Contains(last.Text, "go.mod") {
+		t.Errorf("appended message text should contain tool name + arg hint; got %q", last.Text)
+	}
+}

--- a/internal/tui/toolcall_test.go
+++ b/internal/tui/toolcall_test.go
@@ -93,6 +93,68 @@ func TestRenderMessage_ToolCallShowsIconAndName(t *testing.T) {
 	}
 }
 
+// TestUpdate_ToolCallSplitsAssistantSegments pins the layout fix from
+// the dogfood report: tool calls and the assistant chunks that arrive
+// AFTER them must show up *below* the tool line in the chat, not
+// pinned beneath the assistant text. Concretely:
+//
+//   - Assistant text "before tool" lands in segment A.
+//   - Tool call appended -> segment A is closed (Glamour-rendered, idx
+//     reset).
+//   - Assistant text "after tool" lands in a NEW segment B.
+//   - History order ends up: user, assistant("before tool"),
+//     tool, assistant("after tool").
+//
+// Without this, the user sees the model's response permanently above
+// every tool call and permission prompt of the turn — the bug the
+// user reported as "tool calls and permissions are pinned to the
+// bottom of the viewport".
+//
+// DO NOT silence this test. Re-introducing the pre-created assistant
+// placeholder, or letting handleStreamChunk dump everything into one
+// message regardless of intervening tool calls, brings the bug back.
+func TestUpdate_ToolCallSplitsAssistantSegments(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultConfig()
+	m := NewModel(cfg, nil, "dark")
+	m.Update(tea.WindowSizeMsg{Width: 100, Height: 24})
+
+	// Simulate a turn: state=streaming, no assistant placeholder.
+	m.state = StateStreaming
+	m.currentAssistantIdx = -1
+	m.history.Append(Message{Role: RoleUser, Text: "list files"})
+
+	// First chunk lands BEFORE any tool call.
+	m.Update(streamChunkMsg{Text: "I'll list them for you."})
+	// Tool call closes that segment.
+	m.Update(toolCallMsg{Name: "bash", Args: map[string]any{"command": "ls"}})
+	// Next chunk MUST start a new assistant message below the tool.
+	m.Update(streamChunkMsg{Text: "Here are the files."})
+
+	got := m.history.Snapshot()
+	if len(got) < 4 {
+		t.Fatalf("expected at least 4 history entries (user, assistant1, tool, assistant2); got %d:\n%+v", len(got), got)
+	}
+	wantRoles := []Role{RoleUser, RoleAssistant, RoleTool, RoleAssistant}
+	for i, want := range wantRoles {
+		if got[i].Role != want {
+			t.Errorf("history[%d].Role = %v; want %v\nfull history: %+v", i, got[i].Role, want, got)
+		}
+	}
+	// First assistant segment carries the "before tool" text.
+	if !strings.Contains(got[1].Text, "I'll list them for you") {
+		t.Errorf("history[1] should hold pre-tool assistant text; got %q", got[1].Text)
+	}
+	// Second assistant segment carries the "after tool" text.
+	if !strings.Contains(got[3].Text, "Here are the files") {
+		t.Errorf("history[3] should hold post-tool assistant text; got %q", got[3].Text)
+	}
+	// The pre-tool segment must NOT have absorbed the post-tool text.
+	if strings.Contains(got[1].Text, "Here are the files") {
+		t.Errorf("history[1] absorbed post-tool text; should have been closed when the tool call landed. got: %q", got[1].Text)
+	}
+}
+
 // TestUpdate_ToolCallMsgAppendsHistory pins the wiring from agent
 // goroutine to chat history: a toolCallMsg that arrives in Update
 // MUST cause a RoleTool entry to land in m.history with the formatted

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -104,11 +104,20 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case streamChunkMsg:
 		return m.handleStreamChunk(msg)
 	case toolCallMsg:
-		// Append the tool call as its own history entry. The chat renders
-		// it with the ⚙ icon + accent style so the user sees the agent's
-		// actions interleaved with its prose. The thinking-indicator
-		// placeholder is left alone — it gives way to the next text
-		// chunk on its own.
+		// Tool calls split the assistant's response into segments. Close
+		// out the in-progress assistant message (if any) so the next
+		// streaming chunks land in a fresh assistant message *below*
+		// this tool line. Without this the tool call appears under
+		// the assistant text forever and chunks that arrive after the
+		// tool look out of order.
+		if m.currentAssistantIdx >= 0 {
+			cur := m.history.Snapshot()[m.currentAssistantIdx]
+			if cur.Text != "" {
+				rendered := strings.TrimRight(m.md.Render(cur.Text), "\n")
+				m.history.SetRendered(m.currentAssistantIdx, rendered)
+			}
+			m.currentAssistantIdx = -1
+		}
 		m.history.Append(Message{Role: RoleTool, Text: formatToolCall(msg.Name, msg.Args)})
 		m.refreshViewport()
 		return m, nil
@@ -619,8 +628,14 @@ func (m *Model) handleSubmit() (tea.Model, tea.Cmd) {
 	}
 	m.textarea.Reset()
 	m.palette = nil
-	idx := m.history.Append(Message{Role: RoleAssistant})
-	m.currentAssistantIdx = idx
+	// Don't pre-create an assistant placeholder. The first text chunk
+	// (handleStreamChunk) lazily creates one; tool calls that arrive
+	// before any text aren't pinned beneath an empty placeholder.
+	// Every tool call closes the current assistant segment so the
+	// NEXT chunk starts a fresh assistant message below the tool
+	// line — that's how the user sees the model's response after the
+	// tool calls / permission prompts, not above them.
+	m.currentAssistantIdx = -1
 	m.state = StateStreaming
 	// Reset the thinking-phrase rotator so every turn starts on the
 	// anchor phrase ("Thinking…") and the cycle is predictable.
@@ -807,8 +822,17 @@ func (m *Model) switchModel(modelID string) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) handleStreamChunk(msg streamChunkMsg) (tea.Model, tea.Cmd) {
-	if m.currentAssistantIdx < 0 {
+	// Outside a streaming turn the chunk is stale — drop it.
+	if m.state != StateStreaming {
 		return m, nil
+	}
+	// Lazily create the assistant message on the first chunk of each
+	// segment. handleSubmit clears currentAssistantIdx so the very
+	// first chunk of a turn lands here, and toolCallMsg clears it
+	// again so chunks after a tool call start a new message below
+	// the tool line.
+	if m.currentAssistantIdx < 0 {
+		m.currentAssistantIdx = m.history.Append(Message{Role: RoleAssistant})
 	}
 	m.history.AppendText(m.currentAssistantIdx, msg.Text)
 	m.refreshViewport()

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -103,6 +103,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, textinput.Blink
 	case streamChunkMsg:
 		return m.handleStreamChunk(msg)
+	case toolCallMsg:
+		// Append the tool call as its own history entry. The chat renders
+		// it with the ⚙ icon + accent style so the user sees the agent's
+		// actions interleaved with its prose. The thinking-indicator
+		// placeholder is left alone — it gives way to the next text
+		// chunk on its own.
+		m.history.Append(Message{Role: RoleTool, Text: formatToolCall(msg.Name, msg.Args)})
+		m.refreshViewport()
+		return m, nil
 	case usageMsg:
 		if m.usage != nil {
 			pricing := usage.PriceFor(m.cfg.Model.Name, m.cfg)


### PR DESCRIPTION
feat(tui): show tool calls in the chat window

When the agent invokes a tool mid-turn, surface a one-line summary
in the chat between assistant chunks so the user can see the agent's
actions instead of just its prose.

Wire-up:

- agentcmd.go inspects each ADK event for FunctionCall parts and
  emits a toolCallMsg per call. This runs alongside the existing
  text-chunk extraction so a turn that mixes prose + tool calls
  keeps both interleaved correctly.
- A new RoleTool message role lands the tool line in the chat
  history; renderMessage renders it with a "⚙  <name> · <hint>"
  format.
- formatToolCall + toolArgHint pull a one-line argument summary out
  of the call's args map for cogo's built-in tools (bash, read_file,
  write_file, grep, list_files). Unknown tools fall back to the bare
  name — better empty than misleading. The hint is capped at 200
  chars so a 4 KB heredoc or a giant inlined file can't blow out a
  single chat row.

Styling:

The tool line is rendered through m.styles.HeaderAccent — the same
lipgloss + AdaptiveColor path used by the model name in the header.
That path has been stable on every host we test, including the VS
Code WebGL terminal that's mishandled brand-cyan + raw ANSI in
earlier features (see PR #65 / #66 thread). We deliberately avoid
fixed truecolor / italic / bold-only-via-raw-SGR for the same
reason. Visual distinctness comes from the icon + accent-vs-muted
contrast versus the System / Footer styles, not from a new color.

Tests pin three contracts under "do not silence":

- TestFormatToolCall covers each known built-in's hint extraction
  and the bare-name fallback for unknowns.
- TestFormatToolCall_LongHintTruncated guards the 200-char cap.
- TestRenderMessage_ToolCallShowsIconAndName asserts the rendered
  viewport contains the ⚙ icon, the tool name, and the hint.
- TestUpdate_ToolCallMsgAppendsHistory pins the agent → TUI wiring:
  a toolCallMsg arriving in Update lands a RoleTool entry in
  history with the formatted summary text.

Out of scope for this PR (deliberately): tool-result rendering,
permission-denied styling, full args dump. Those are easy follow-ups
once we see how the basic display feels in real use.