### PR TITLE
feat(permissions): add "[t] this tool · session" prompt option

### DIFF
--- a/internal/permissions/gate.go
+++ b/internal/permissions/gate.go
@@ -40,6 +40,12 @@ type Gate struct {
 	// DecisionAllowSession choices so we don't re-prompt the same call
 	// repeatedly within one session.
 	sessionAllow map[string]struct{}
+	// Tool-wide in-session allow set, keyed by tool name only.
+	// Populated by DecisionAllowSessionTool when the user trusts an
+	// entire tool for the rest of the session ("allow every read_file
+	// call regardless of path"). Bash denylist still applies — that
+	// pre-check runs before the gate ever sees the request.
+	sessionAllowTools map[string]struct{}
 }
 
 // Options configures a Gate at construction time. All fields are
@@ -64,11 +70,12 @@ func New(opts Options) *Gate {
 		opts.Scope, _ = NewPathScope("", "", nil)
 	}
 	return &Gate{
-		mode:         opts.Mode,
-		policy:       opts.Policy,
-		scope:        opts.Scope,
-		prompter:     opts.Prompter,
-		sessionAllow: make(map[string]struct{}),
+		mode:              opts.Mode,
+		policy:            opts.Policy,
+		scope:             opts.Scope,
+		prompter:          opts.Prompter,
+		sessionAllow:      make(map[string]struct{}),
+		sessionAllowTools: make(map[string]struct{}),
 	}
 }
 
@@ -124,6 +131,12 @@ func (g *Gate) CheckBash(ctx context.Context, command string) error {
 // fails if the path is out of scope (and the user can't or won't
 // extend scope).
 func (g *Gate) CheckFileRead(ctx context.Context, toolName, path string) error {
+	// "Allow this tool · session" trusts the tool entirely for the
+	// session, including out-of-scope paths. Short-circuit before the
+	// scope check so the user doesn't get re-prompted.
+	if g.sessionToolAllowed(toolName) {
+		return nil
+	}
 	in, err := g.scope.Contains(path)
 	if err != nil {
 		return err
@@ -138,6 +151,12 @@ func (g *Gate) CheckFileRead(ctx context.Context, toolName, path string) error {
 // are escalated via prompt; in-scope paths still go through mode-aware
 // approval (ask mode prompts; allow/yolo proceed unless deny rule hits).
 func (g *Gate) CheckFileWrite(ctx context.Context, toolName, path string) error {
+	// "Allow this tool · session" trusts the tool entirely (mirrors
+	// CheckFileRead). The user opted in explicitly for the rest of
+	// the session.
+	if g.sessionToolAllowed(toolName) {
+		return nil
+	}
 	in, err := g.scope.Contains(path)
 	if err != nil {
 		return err
@@ -155,6 +174,12 @@ func (g *Gate) gateRequest(ctx context.Context, kind PromptKind, toolName, key, 
 	case OutcomeDeny:
 		return fmt.Errorf("%s denied by config policy: %q", toolName, key)
 	case OutcomeAllow:
+		return nil
+	}
+	// Tool-wide session allow short-circuits before per-key session
+	// allow so a user who picked "allow this tool · session" never
+	// sees another modal for the same tool.
+	if g.sessionToolAllowed(toolName) {
 		return nil
 	}
 	if g.sessionAllowed(toolName, key) {
@@ -215,6 +240,13 @@ func (g *Gate) prompt(ctx context.Context, req PromptRequest) error {
 	case DecisionAllowSession:
 		g.rememberSession(req.ToolName, req.Detail)
 		return nil
+	case DecisionAllowSessionTool:
+		// "Trust the whole tool for this session." We remember the
+		// per-key entry too so any in-flight retry of the same call
+		// doesn't re-prompt before the tool-wide entry takes effect.
+		g.rememberSessionTool(req.ToolName)
+		g.rememberSession(req.ToolName, req.Detail)
+		return nil
 	case DecisionAllowAlways:
 		// Caller (e.g. TUI host) is responsible for persisting the
 		// pattern via the config layer; the gate also remembers it
@@ -241,4 +273,19 @@ func (g *Gate) rememberSession(toolName, key string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.sessionAllow[toolName+"|"+key] = struct{}{}
+}
+
+// sessionToolAllowed reports whether the user has trusted toolName
+// entirely for this session via DecisionAllowSessionTool.
+func (g *Gate) sessionToolAllowed(toolName string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	_, ok := g.sessionAllowTools[toolName]
+	return ok
+}
+
+func (g *Gate) rememberSessionTool(toolName string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.sessionAllowTools[toolName] = struct{}{}
 }

--- a/internal/permissions/prompter.go
+++ b/internal/permissions/prompter.go
@@ -12,10 +12,11 @@ import (
 type Decision int
 
 const (
-	DecisionDeny         Decision = iota // reject this call
-	DecisionAllowOnce                    // allow this call, ask again next time
-	DecisionAllowSession                 // allow this exact request for the rest of the session
-	DecisionAllowAlways                  // persist a permanent allowlist entry, then allow
+	DecisionDeny             Decision = iota // reject this call
+	DecisionAllowOnce                        // allow this call, ask again next time
+	DecisionAllowSession                     // allow this exact request for the rest of the session
+	DecisionAllowSessionTool                 // allow EVERY call to this tool for the rest of the session, regardless of args
+	DecisionAllowAlways                      // persist a permanent allowlist entry, then allow
 )
 
 // String renders Decision for diagnostics.
@@ -27,6 +28,8 @@ func (d Decision) String() string {
 		return "allow-once"
 	case DecisionAllowSession:
 		return "allow-session"
+	case DecisionAllowSessionTool:
+		return "allow-session-tool"
 	case DecisionAllowAlways:
 		return "allow-always"
 	default:

--- a/internal/permissions/sessiontool_test.go
+++ b/internal/permissions/sessiontool_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 The Cogo Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package permissions
+
+import (
+	"context"
+	"testing"
+)
+
+// TestGate_DecisionAllowSessionTool_SuppressesFurtherPrompts pins the
+// v0.1.3 contract: once the user picks DecisionAllowSessionTool on a
+// prompt for tool X, every subsequent gate request for tool X (any
+// args, any file, any path) MUST go through without prompting again
+// until the session ends. The whole point of the feature is to stop
+// re-prompting for read_file / ls / etc.
+//
+// DO NOT silence this test. A failure means the user clicked
+// "[t] this tool · session", which exists only to suppress further
+// prompts, and immediately got prompted again. That defeats the
+// affordance entirely.
+func TestGate_DecisionAllowSessionTool_SuppressesFurtherPrompts(t *testing.T) {
+	t.Parallel()
+	prompter := &fakePrompter{decision: DecisionAllowSessionTool}
+	g := New(Options{Mode: ModeAsk, Prompter: prompter})
+
+	ctx := context.Background()
+	// First call prompts and the user picks "tool · session".
+	if err := g.CheckGeneric(ctx, "read_file", "go.mod"); err != nil {
+		t.Fatalf("first call: unexpected error: %v", err)
+	}
+	if len(prompter.calls) != 1 {
+		t.Fatalf("first call should prompt exactly once; got %d", len(prompter.calls))
+	}
+
+	// All subsequent read_file calls — different keys — must NOT prompt.
+	for _, key := range []string{"go.sum", "internal/tui/model.go", "README.md", "anything-else"} {
+		if err := g.CheckGeneric(ctx, "read_file", key); err != nil {
+			t.Errorf("read_file %q after AllowSessionTool: unexpected error %v", key, err)
+		}
+	}
+	if len(prompter.calls) != 1 {
+		t.Errorf("subsequent read_file calls should be silent; prompter was called %d times total", len(prompter.calls))
+	}
+
+	// A different tool still prompts — AllowSessionTool only trusts
+	// the tool that was approved, not every tool.
+	if err := g.CheckGeneric(ctx, "bash", "ls -la"); err != nil {
+		t.Errorf("bash call: unexpected error %v", err)
+	}
+	if len(prompter.calls) != 2 {
+		t.Errorf("a different tool should still prompt; got total prompter.calls=%d, want 2", len(prompter.calls))
+	}
+}
+
+// TestGate_FileReadWrite_SkipScopeCheckOnSessionTool covers the file-
+// path branch. Once read_file (or write_file) is trusted tool-wide,
+// even out-of-scope paths must go through without an additional path-
+// scope prompt. Without this the user gets re-prompted on every
+// out-of-scope file access despite already trusting the tool.
+func TestGate_FileReadWrite_SkipScopeCheckOnSessionTool(t *testing.T) {
+	t.Parallel()
+	prompter := &fakePrompter{decision: DecisionAllowSessionTool}
+	scope, err := NewPathScope("/tmp/in-scope", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := New(Options{Mode: ModeAsk, Scope: scope, Prompter: prompter})
+
+	ctx := context.Background()
+	// Out-of-scope read prompts the user once; they pick AllowSessionTool.
+	if err := g.CheckFileRead(ctx, "read_file", "/etc/hosts"); err != nil {
+		t.Fatalf("first out-of-scope read: unexpected error: %v", err)
+	}
+	if len(prompter.calls) != 1 {
+		t.Fatalf("first out-of-scope read should prompt; got %d", len(prompter.calls))
+	}
+
+	// Subsequent reads of any path must not re-prompt.
+	for _, p := range []string{"/etc/passwd", "/var/log/syslog", "/srv/secret"} {
+		if err := g.CheckFileRead(ctx, "read_file", p); err != nil {
+			t.Errorf("read_file %q after AllowSessionTool: unexpected error %v", p, err)
+		}
+	}
+	if len(prompter.calls) != 1 {
+		t.Errorf("post-AllowSessionTool reads should be silent; got total %d", len(prompter.calls))
+	}
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -20,10 +20,11 @@ type KeyMap struct {
 
 	// Permission modal: y allow once, n deny, s allow for the session,
 	// a allow always (persisted).
-	ConfirmAllowOnce    key.Binding
-	ConfirmDeny         key.Binding
-	ConfirmAllowSession key.Binding
-	ConfirmAllowAlways  key.Binding
+	ConfirmAllowOnce        key.Binding
+	ConfirmDeny             key.Binding
+	ConfirmAllowSession     key.Binding
+	ConfirmAllowSessionTool key.Binding
+	ConfirmAllowAlways      key.Binding
 }
 
 // DefaultKeyMap returns Cogo's V1 bindings.
@@ -75,7 +76,11 @@ func DefaultKeyMap() KeyMap {
 		),
 		ConfirmAllowSession: key.NewBinding(
 			key.WithKeys("s"),
-			key.WithHelp("s", "allow for this session"),
+			key.WithHelp("s", "allow this call for the session"),
+		),
+		ConfirmAllowSessionTool: key.NewBinding(
+			key.WithKeys("t"),
+			key.WithHelp("t", "allow this tool for the session"),
 		),
 		ConfirmAllowAlways: key.NewBinding(
 			key.WithKeys("a"),

--- a/internal/tui/program_test.go
+++ b/internal/tui/program_test.go
@@ -453,7 +453,7 @@ func TestProgram_PermissionModalApprovesAndDenies(t *testing.T) {
 	// Modal should appear in the rendered output.
 	teatest.WaitFor(t, tm.Output(), func(o []byte) bool {
 		return bytes.Contains(o, []byte("git push origin main")) &&
-			bytes.Contains(o, []byte("[y] allow once"))
+			bytes.Contains(o, []byte("[y] once"))
 	}, teatest.WithDuration(2*time.Second))
 
 	// Approve once.

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -170,6 +170,8 @@ func (m *Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		d = permissions.DecisionAllowOnce
 	case key.Matches(msg, m.keys.ConfirmAllowSession):
 		d = permissions.DecisionAllowSession
+	case key.Matches(msg, m.keys.ConfirmAllowSessionTool):
+		d = permissions.DecisionAllowSessionTool
 	case key.Matches(msg, m.keys.ConfirmAllowAlways):
 		d = permissions.DecisionAllowAlways
 	case key.Matches(msg, m.keys.ConfirmDeny):

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -235,7 +235,7 @@ func (m *Model) renderConfirmModal() string {
 		kindLabel = "Tool"
 	}
 	body := m.styles.Confirm.Render(kindLabel+": "+req.Detail) + "\n" +
-		m.styles.Footer.Render("[y] allow once   [s] allow session   [a] always allow   [n/esc] deny")
+		m.styles.Footer.Render("[y] once  [s] this call · session  [t] this tool · session  [a] always (persist)  [n/esc] deny")
 	return m.styles.InputBorder.Render(body)
 }
 


### PR DESCRIPTION
feat(permissions): add "[t] this tool · session" prompt option

The existing "[s] allow session" only allows the exact tool+args
pair the user approved, so a chat that does ten ls commands or
opens five files needs ten / five separate prompts. Add a coarser
opt-in: pressing [t] at the permission modal trusts the WHOLE tool
(read_file, bash, ls, etc.) for the rest of the session, regardless
of args or path.

Wire-up:

- New permissions.DecisionAllowSessionTool decision.
- Gate gains sessionAllowTools (a tool-name set) and a
  sessionToolAllowed helper. gateRequest, CheckFileRead, and
  CheckFileWrite all consult it before per-key checks so trusted
  tools never re-prompt — including for out-of-scope file paths.
- The bash denylist still applies; the pre-check runs before the
  gate ever sees the request, so [t] on bash can't smuggle past
  rm -rf / etc.
- Decisions never persist beyond the session. Users who want
  permanent trust still use the existing "permissions.allow"
  config glob (e.g. "bash:git status").

TUI:

- New ConfirmAllowSessionTool key binding ("t").
- handleConfirmKey routes [t] to DecisionAllowSessionTool.
- Modal footer now reads:
  [y] once  [s] this call · session  [t] this tool · session  [a] always (persist)  [n/esc] deny

Tests:

- TestGate_DecisionAllowSessionTool_SuppressesFurtherPrompts pins
  the core contract — once [t] is picked for tool X, future calls
  to X with any args MUST go through silently, while a different
  tool still prompts.
- TestGate_FileReadWrite_SkipScopeCheckOnSessionTool covers the
  file branch: out-of-scope reads/writes via a trusted tool must
  also skip re-prompts.
- Both carry the project's "do not silence this test" comment so
  the affordance can't be quietly weakened.
- Existing TestProgram_PermissionModalApprovesAndDenies updated
  to match the rewritten footer.