### PR TITLE
feat(tui): /permissions reviews session approvals + persists chosen ones

### DIFF
--- a/internal/permissions/gate.go
+++ b/internal/permissions/gate.go
@@ -8,9 +8,21 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-steer/cogo/internal/config"
 )
+
+// ApprovalLog is one entry in the gate's per-session approval audit.
+// It records every interactive permission decision the user made
+// (excluding denials) so the TUI can later offer a "review approvals
+// + recommend" workflow via the /permissions slash command.
+type ApprovalLog struct {
+	Tool     string
+	Key      string
+	Decision Decision
+	At       time.Time
+}
 
 // Mode mirrors the permission modes documented in REQUIREMENTS §3.10.
 type Mode string
@@ -46,6 +58,11 @@ type Gate struct {
 	// call regardless of path"). Bash denylist still applies — that
 	// pre-check runs before the gate ever sees the request.
 	sessionAllowTools map[string]struct{}
+
+	// Chronological log of every non-deny interactive approval. Surfaces
+	// via Approvals() so /permissions can recommend allowlist entries
+	// based on what the user actually approved this session.
+	approvals []ApprovalLog
 }
 
 // Options configures a Gate at construction time. All fields are
@@ -236,9 +253,11 @@ func (g *Gate) prompt(ctx context.Context, req PromptRequest) error {
 	}
 	switch d {
 	case DecisionAllowOnce:
+		g.recordApproval(req.ToolName, req.Detail, d)
 		return nil
 	case DecisionAllowSession:
 		g.rememberSession(req.ToolName, req.Detail)
+		g.recordApproval(req.ToolName, req.Detail, d)
 		return nil
 	case DecisionAllowSessionTool:
 		// "Trust the whole tool for this session." We remember the
@@ -246,6 +265,7 @@ func (g *Gate) prompt(ctx context.Context, req PromptRequest) error {
 		// doesn't re-prompt before the tool-wide entry takes effect.
 		g.rememberSessionTool(req.ToolName)
 		g.rememberSession(req.ToolName, req.Detail)
+		g.recordApproval(req.ToolName, req.Detail, d)
 		return nil
 	case DecisionAllowAlways:
 		// Caller (e.g. TUI host) is responsible for persisting the
@@ -256,6 +276,7 @@ func (g *Gate) prompt(ctx context.Context, req PromptRequest) error {
 		if req.Kind == PromptKindPathScope {
 			g.scope.AddAlwaysAllow(req.PersistKey)
 		}
+		g.recordApproval(req.ToolName, req.Detail, d)
 		return nil
 	default:
 		return fmt.Errorf("%s denied by user: %s", req.ToolName, req.Detail)
@@ -288,4 +309,28 @@ func (g *Gate) rememberSessionTool(toolName string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.sessionAllowTools[toolName] = struct{}{}
+}
+
+// recordApproval appends an interactive approval to the session's
+// audit log. /permissions reads this back to recommend allowlist
+// entries based on what the user actually approved.
+func (g *Gate) recordApproval(toolName, key string, d Decision) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.approvals = append(g.approvals, ApprovalLog{
+		Tool:     toolName,
+		Key:      key,
+		Decision: d,
+		At:       time.Now(),
+	})
+}
+
+// Approvals returns a defensive copy of the in-session approval log.
+// Order is chronological. Safe for concurrent callers.
+func (g *Gate) Approvals() []ApprovalLog {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	out := make([]ApprovalLog, len(g.approvals))
+	copy(out, g.approvals)
+	return out
 }

--- a/internal/permissions/recommend.go
+++ b/internal/permissions/recommend.go
@@ -1,0 +1,242 @@
+// Copyright 2026 The Cogo Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package permissions
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Recommendation describes one suggested allowlist entry the user
+// could persist into .agents/config.json's `permissions.allow` block.
+// Pattern is in the existing tool:glob form — see internal/permissions
+// policy.go for the grammar — so a recommendation can be appended
+// verbatim. Reason and Evidence let the picker explain WHY before the
+// user agrees to broaden their permanent allowlist.
+type Recommendation struct {
+	Pattern  string   // e.g. "bash:git *", "read_file:internal/tui/**"
+	Reason   string   // one-line human explanation of what this covers
+	Evidence []string // sample keys that motivated the recommendation
+}
+
+// Recommend turns a session's interactive approval log into a small
+// list of suggested permanent allowlist entries. Heuristics, not
+// magic — the rules below were chosen to surface the patterns that
+// dogfood actually produces (lots of `git`, lots of reads under the
+// project tree, the same `ls -la` over and over). Anything that
+// can't be classified is skipped; an empty result is normal for a
+// session that did one-off things.
+//
+// The classifier is deterministic so the picker can show stable
+// recommendations across rerenders.
+func Recommend(approvals []ApprovalLog) []Recommendation {
+	if len(approvals) == 0 {
+		return nil
+	}
+	// Group keys by tool, deduping while preserving first-seen order
+	// so the evidence list reads chronologically.
+	byTool := map[string][]string{}
+	seen := map[string]bool{}
+	tools := []string{}
+	for _, a := range approvals {
+		if !seen[a.Tool] {
+			tools = append(tools, a.Tool)
+		}
+		k := a.Tool + "|" + a.Key
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		seen[a.Tool] = true
+		byTool[a.Tool] = append(byTool[a.Tool], a.Key)
+	}
+
+	var out []Recommendation
+	for _, tool := range tools {
+		out = append(out, classify(tool, byTool[tool])...)
+	}
+	return out
+}
+
+// classify produces 0-2 recommendations for one tool's approved keys.
+func classify(tool string, keys []string) []Recommendation {
+	if len(keys) == 0 {
+		return nil
+	}
+
+	// Single key approved at least once -> recommend the exact pattern
+	// only if it was approved 3+ times (signal that it's frequent).
+	// Approval count is reflected in len(keys) only when keys are
+	// distinct; for repeats we'd see one entry. So this branch covers
+	// "the user approved the same one-off twice" which is rarely
+	// worth persisting; we let it fall through.
+	if len(keys) == 1 {
+		// Single distinct key. Recommend the exact pattern verbatim;
+		// the picker will show the count of approvals separately if
+		// needed. Tool author can decide if this is worth pinning.
+		return []Recommendation{{
+			Pattern:  tool + ":" + keys[0],
+			Reason:   "approved once this session — pin if you'll keep doing it",
+			Evidence: keys,
+		}}
+	}
+
+	// Bash-specific: detect a shared leading verb (git, npm, go, etc.)
+	// because that's the highest-signal pattern in dogfood.
+	if tool == "bash" {
+		if verb, all := bashCommonVerb(keys); verb != "" && all {
+			return []Recommendation{
+				{
+					Pattern:  "bash:" + verb + " *",
+					Reason:   "all " + plural(len(keys), "command") + " start with `" + verb + "` — persist a verb-wide allow",
+					Evidence: keys,
+				},
+			}
+		}
+	}
+
+	// File-tool path-prefix detection: if all keys share a common
+	// directory prefix, recommend that directory glob.
+	if isFileTool(tool) {
+		if pref := commonDirPrefix(keys); pref != "" && pref != "." && pref != "/" {
+			return []Recommendation{{
+				Pattern:  tool + ":" + pref + "/**",
+				Reason:   plural(len(keys), "path") + " under `" + pref + "/` approved",
+				Evidence: keys,
+			}}
+		}
+	}
+
+	// Final fallback: tool-wide. Broader than the user might want,
+	// but we always show it as a separate recommendation so they can
+	// opt out by leaving it unchecked.
+	return []Recommendation{{
+		Pattern:  tool + ":*",
+		Reason:   plural(len(keys), "distinct call") + " — broaden to all " + tool + " calls",
+		Evidence: keys,
+	}}
+}
+
+// bashCommonVerb returns the leading whitespace-separated token if
+// every key in keys starts with that same token (e.g. "git status",
+// "git log -p" → "git"). Returns ("", false) if there's no match.
+func bashCommonVerb(keys []string) (string, bool) {
+	if len(keys) == 0 {
+		return "", false
+	}
+	first := strings.Fields(keys[0])
+	if len(first) == 0 {
+		return "", false
+	}
+	verb := first[0]
+	for _, k := range keys[1:] {
+		toks := strings.Fields(k)
+		if len(toks) == 0 || toks[0] != verb {
+			return "", false
+		}
+	}
+	return verb, true
+}
+
+// isFileTool reports whether the given tool's keys are filesystem
+// paths (vs. command strings). Conservative — only the cogo built-ins
+// that we know take a path argument.
+func isFileTool(tool string) bool {
+	switch tool {
+	case "read_file", "write_file", "edit_file", "list_dir":
+		return true
+	}
+	return false
+}
+
+// commonDirPrefix returns the longest leading directory shared by every
+// path in paths. Returns "" if there's no useful (non-root) prefix.
+func commonDirPrefix(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	// Split each path into its directory components and find the
+	// longest shared prefix.
+	cleaned := make([][]string, len(paths))
+	for i, p := range paths {
+		cleaned[i] = strings.Split(filepath.ToSlash(filepath.Clean(p)), "/")
+	}
+	prefix := append([]string(nil), cleaned[0]...)
+	for _, parts := range cleaned[1:] {
+		// Trim prefix to the matching head with parts.
+		max := len(prefix)
+		if len(parts) < max {
+			max = len(parts)
+		}
+		i := 0
+		for i < max && prefix[i] == parts[i] {
+			i++
+		}
+		prefix = prefix[:i]
+		if len(prefix) == 0 {
+			return ""
+		}
+	}
+	// We want the directory prefix, not a complete-match path. If the
+	// full path matched, drop the basename so we recommend the parent.
+	for _, parts := range cleaned {
+		if len(parts) == len(prefix) {
+			prefix = prefix[:len(prefix)-1]
+			break
+		}
+	}
+	if len(prefix) == 0 {
+		return ""
+	}
+	return strings.Join(prefix, "/")
+}
+
+// plural returns "<n> <word>" or "<n> <word>s" depending on n. No
+// fancy English handling beyond the trailing s — the recommendations
+// only use simple nouns.
+func plural(n int, word string) string {
+	if n == 1 {
+		return "1 " + word
+	}
+	return itoa(n) + " " + word + "s"
+}
+
+// itoa avoids pulling in strconv just for one call site.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// SortRecommendations returns a stable ordering: more specific
+// patterns (without `*`) first, then by Pattern lex order. The
+// picker shows them in this order so the safer recommendations
+// surface above the broad tool-wide ones.
+func SortRecommendations(recs []Recommendation) {
+	sort.SliceStable(recs, func(i, j int) bool {
+		ai := strings.Contains(recs[i].Pattern, "*")
+		aj := strings.Contains(recs[j].Pattern, "*")
+		if ai != aj {
+			return !ai // non-wildcard first
+		}
+		return recs[i].Pattern < recs[j].Pattern
+	})
+}

--- a/internal/permissions/recommend_test.go
+++ b/internal/permissions/recommend_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 The Cogo Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package permissions
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func mkApprovals(rows ...[2]string) []ApprovalLog {
+	out := make([]ApprovalLog, 0, len(rows))
+	now := time.Now()
+	for _, r := range rows {
+		out = append(out, ApprovalLog{Tool: r[0], Key: r[1], Decision: DecisionAllowOnce, At: now})
+	}
+	return out
+}
+
+func patterns(recs []Recommendation) []string {
+	out := make([]string, len(recs))
+	for i, r := range recs {
+		out[i] = r.Pattern
+	}
+	return out
+}
+
+// TestRecommend covers each classification branch the picker relies
+// on. The recommendation list IS the user-facing surface of the
+// /permissions feature, so wrong patterns here mean wrong allowlist
+// entries get persisted to .agents/config.json.
+func TestRecommend(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		input  []ApprovalLog
+		expect []string
+	}{
+		{
+			"empty log -> nothing",
+			nil,
+			nil,
+		},
+		{
+			"single bash command -> exact pattern",
+			mkApprovals([2]string{"bash", "git status"}),
+			[]string{"bash:git status"},
+		},
+		{
+			"multiple bash sharing a verb -> verb glob",
+			mkApprovals(
+				[2]string{"bash", "git status"},
+				[2]string{"bash", "git log -p"},
+				[2]string{"bash", "git diff HEAD"},
+			),
+			[]string{"bash:git *"},
+		},
+		{
+			"multiple bash with no shared verb -> tool-wide",
+			mkApprovals(
+				[2]string{"bash", "ls -la"},
+				[2]string{"bash", "pwd"},
+				[2]string{"bash", "echo hi"},
+			),
+			[]string{"bash:*"},
+		},
+		{
+			"file reads with shared dir prefix -> path glob",
+			mkApprovals(
+				[2]string{"read_file", "internal/tui/model.go"},
+				[2]string{"read_file", "internal/tui/view.go"},
+				[2]string{"read_file", "internal/tui/update.go"},
+			),
+			[]string{"read_file:internal/tui/**"},
+		},
+		{
+			"file reads with no shared dir -> tool-wide",
+			mkApprovals(
+				[2]string{"read_file", "go.mod"},
+				[2]string{"read_file", "README.md"},
+				[2]string{"read_file", "Makefile"},
+			),
+			[]string{"read_file:*"},
+		},
+		{
+			"two tools each get their own recommendation",
+			mkApprovals(
+				[2]string{"bash", "git status"},
+				[2]string{"bash", "git log"},
+				[2]string{"read_file", "go.mod"},
+			),
+			[]string{"bash:git *", "read_file:go.mod"},
+		},
+		{
+			"duplicate keys collapse to one",
+			mkApprovals(
+				[2]string{"bash", "git status"},
+				[2]string{"bash", "git status"},
+				[2]string{"bash", "git status"},
+			),
+			[]string{"bash:git status"},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := patterns(Recommend(tc.input))
+			if !sliceEq(got, tc.expect) {
+				t.Errorf("Recommend produced %v; want %v", got, tc.expect)
+			}
+		})
+	}
+}
+
+// TestRecommend_FileToolPrefixDropsBasename guards a subtle case:
+// when EVERY approved path is the same file (so the longest common
+// prefix is the file itself), we must back off to the parent
+// directory rather than emitting a useless "<file>/**" pattern.
+func TestRecommend_FileToolPrefixDropsBasename(t *testing.T) {
+	t.Parallel()
+	// All paths share `internal/tui/model.go` exactly; the prefix
+	// algorithm should fall back to the parent directory.
+	got := patterns(Recommend(mkApprovals(
+		[2]string{"read_file", "internal/tui/model.go"},
+		[2]string{"read_file", "internal/tui/model.go"},
+	)))
+	for _, p := range got {
+		if strings.HasSuffix(p, ".go/**") {
+			t.Errorf("recommendation %q glob-pasted onto a filename, not a directory", p)
+		}
+	}
+}
+
+// TestSortRecommendations pins the picker ordering: specific patterns
+// (no `*`) above wildcard patterns. Otherwise the safer recommendation
+// hides below the broad one and a hurried user might pick the wrong one.
+func TestSortRecommendations(t *testing.T) {
+	t.Parallel()
+	recs := []Recommendation{
+		{Pattern: "bash:*"},
+		{Pattern: "read_file:go.mod"},
+		{Pattern: "bash:git *"},
+		{Pattern: "read_file:internal/tui/**"},
+	}
+	SortRecommendations(recs)
+	got := patterns(recs)
+	want := []string{"read_file:go.mod", "bash:*", "bash:git *", "read_file:internal/tui/**"}
+	if !sliceEq(got, want) {
+		t.Errorf("SortRecommendations -> %v; want %v", got, want)
+	}
+}
+
+func sliceEq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -9,36 +9,39 @@ import "strings"
 type SlashAction string
 
 const (
-	SlashHelp    SlashAction = "help"
-	SlashClear   SlashAction = "clear"
-	SlashQuit    SlashAction = "quit"
-	SlashMemory  SlashAction = "memory"
-	SlashStats   SlashAction = "stats"
-	SlashModel   SlashAction = "model"
-	SlashMCP     SlashAction = "mcp"
-	SlashSkills  SlashAction = "skills"
-	SlashReload  SlashAction = "reload"
-	SlashMouse   SlashAction = "mouse"
-	SlashUnknown SlashAction = "unknown"
+	SlashHelp        SlashAction = "help"
+	SlashClear       SlashAction = "clear"
+	SlashQuit        SlashAction = "quit"
+	SlashMemory      SlashAction = "memory"
+	SlashStats       SlashAction = "stats"
+	SlashModel       SlashAction = "model"
+	SlashMCP         SlashAction = "mcp"
+	SlashSkills      SlashAction = "skills"
+	SlashReload      SlashAction = "reload"
+	SlashMouse       SlashAction = "mouse"
+	SlashPermissions SlashAction = "permissions"
+	SlashUnknown     SlashAction = "unknown"
 )
 
 // Slash command names accepted in V1. /mcp + /skills + /init join in
 // Slice 4b alongside MCP, skills, and the init wizard.
 var slashAliases = map[string]SlashAction{
-	"help":   SlashHelp,
-	"?":      SlashHelp,
-	"clear":  SlashClear,
-	"quit":   SlashQuit,
-	"exit":   SlashQuit,
-	"q":      SlashQuit,
-	"memory": SlashMemory,
-	"stats":  SlashStats,
-	"model":  SlashModel,
-	"models": SlashModel,
-	"mcp":    SlashMCP,
-	"skills": SlashSkills,
-	"reload": SlashReload,
-	"mouse":  SlashMouse,
+	"help":        SlashHelp,
+	"?":           SlashHelp,
+	"clear":       SlashClear,
+	"quit":        SlashQuit,
+	"exit":        SlashQuit,
+	"q":           SlashQuit,
+	"memory":      SlashMemory,
+	"stats":       SlashStats,
+	"model":       SlashModel,
+	"models":      SlashModel,
+	"mcp":         SlashMCP,
+	"skills":      SlashSkills,
+	"reload":      SlashReload,
+	"mouse":       SlashMouse,
+	"permissions": SlashPermissions,
+	"perms":       SlashPermissions,
 }
 
 // ParseSlash inspects input. If it looks like a slash command (leading
@@ -96,6 +99,7 @@ func HelpText() string {
 		"  /skills     show discovered skills",
 		"  /reload     re-read .agents/ from disk (mcp.json, skills/, AGENTS.md, config.json)",
 		"  /mouse      toggle mouse-wheel scrolling (or /mouse on|off)",
+		"  /permissions  review session approvals + add recommended allowlist entries (alias: /perms)",
 		"",
 		"Keys:",
 		"  PgUp/PgDn   scroll chat history",

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -111,6 +111,10 @@ type Model struct {
 	// modelPicker is the open Model picker overlay, if any.
 	modelPicker *modelPickerState
 
+	// permissionsPicker is the open /permissions overlay, if any. See
+	// permissions_picker.go for layout + key handling.
+	permissionsPicker *permissionsPicker
+
 	// mcpServers + skills carry the discovered extensibility for
 	// /mcp + /skills rendering. Both are nil-safe.
 	mcpServers []*mcp.Server
@@ -153,6 +157,19 @@ type Model struct {
 	// that persists the pattern to .agents/config.json. May be nil in
 	// tests.
 	AlwaysAllow func(req permissions.PromptRequest) error
+
+	// SessionApprovals returns the gate's chronological approval log
+	// for the current session. Used by the /permissions slash command
+	// to drive the recommendation picker. May be nil in tests; in
+	// that case /permissions reports nothing-to-review.
+	SessionApprovals func() []permissions.ApprovalLog
+
+	// PersistAllowPatterns appends one or more allowlist patterns to
+	// .agents/config.json's permissions.allow block. The picker calls
+	// it when the user confirms their selection. May be nil when
+	// running without a project root; the picker reports the lack of
+	// persistence to the user as a system message.
+	PersistAllowPatterns func(patterns []string) error
 }
 
 // NewModel constructs a fresh chat session bound to a configured agent.

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -61,6 +61,7 @@ func allSlashItems() []paletteItem {
 		{Display: "/skills", Value: "/skills", Hint: "discovered skill bundles"},
 		{Display: "/reload", Value: "/reload", Hint: "re-read .agents/ from disk"},
 		{Display: "/mouse", Value: "/mouse", Hint: "toggle mouse-wheel scrolling"},
+		{Display: "/permissions", Value: "/permissions", Hint: "review approvals + persist recommended allowlist"},
 		{Display: "/clear", Value: "/clear", Hint: "clear chat history"},
 		{Display: "/quit", Value: "/quit", Hint: "exit Cogo"},
 	}

--- a/internal/tui/permissions_picker.go
+++ b/internal/tui/permissions_picker.go
@@ -1,0 +1,153 @@
+// Copyright 2026 The Cogo Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-steer/cogo/internal/permissions"
+)
+
+// permissionsPicker is the overlay state for the /permissions slash
+// command. It mirrors modelPickerState in shape (cursor + items) but
+// adds a per-row toggle so the user can pick which recommendations to
+// persist before pressing enter.
+//
+// Layout in the chat is similar to the model picker: a bordered box
+// in place of the input area while the picker is open. Only the
+// recommendation rows are interactive; the audit list below is
+// read-only context.
+type permissionsPicker struct {
+	recs     []permissions.Recommendation
+	selected []bool   // index-aligned with recs
+	approved []string // formatted approval log lines, for context
+	cursor   int
+}
+
+// newPermissionsPicker builds the picker state from the gate's session
+// approval log. Returns nil when there's nothing to review (so the
+// caller can show a friendly "no approvals yet" system message
+// instead of opening an empty modal).
+func newPermissionsPicker(approvals []permissions.ApprovalLog) *permissionsPicker {
+	if len(approvals) == 0 {
+		return nil
+	}
+	recs := permissions.Recommend(approvals)
+	permissions.SortRecommendations(recs)
+
+	approved := make([]string, 0, len(approvals))
+	for _, a := range approvals {
+		approved = append(approved, fmt.Sprintf("%-12s %s   (%s)", a.Tool, a.Key, a.Decision))
+	}
+	return &permissionsPicker{
+		recs:     recs,
+		selected: make([]bool, len(recs)),
+		approved: approved,
+	}
+}
+
+// chosenPatterns returns the patterns the user toggled on. Empty when
+// nothing's selected; caller treats that as "user wants to bail".
+func (p *permissionsPicker) chosenPatterns() []string {
+	out := make([]string, 0, len(p.recs))
+	for i, r := range p.recs {
+		if p.selected[i] {
+			out = append(out, r.Pattern)
+		}
+	}
+	return out
+}
+
+// renderPermissionsPicker draws the permissions overlay in place of
+// the input area while the picker is open. Layout:
+//
+//	Permissions review
+//	  [x] read_file:internal/tui/**   3 paths under `internal/tui/` approved
+//	    examples: internal/tui/model.go, internal/tui/view.go, ...
+//	  [ ] bash:*                      3 distinct calls — broaden to all bash calls
+//	  ...
+//	Other approvals this session (4)
+//	  read_file    go.mod   (allow-once)
+//	  ...
+//	[↑/↓] move  [space] toggle  [enter] persist checked  [esc] cancel
+func (m *Model) renderPermissionsPicker() string {
+	p := m.permissionsPicker
+	if p == nil {
+		return ""
+	}
+	var lines []string
+	lines = append(lines, m.styles.System.Render("Permissions review (this session)"))
+
+	if len(p.recs) == 0 {
+		lines = append(lines, m.styles.Footer.Render("  no recommendations — every approval was a one-off"))
+	} else {
+		lines = append(lines, m.styles.Footer.Render(
+			fmt.Sprintf("  %s", plural(len(p.recs), "candidate"))))
+		for i, r := range p.recs {
+			marker := "[ ]"
+			if p.selected[i] {
+				marker = "[x]"
+			}
+			cursor := "  "
+			if i == p.cursor {
+				cursor = "▸ "
+			}
+			row := fmt.Sprintf("%s%s %-30s  %s", cursor, marker, r.Pattern, r.Reason)
+			if i == p.cursor {
+				lines = append(lines, m.styles.HeaderAccent.Render(row))
+			} else {
+				lines = append(lines, m.styles.Footer.Render(row))
+			}
+			if len(r.Evidence) > 0 {
+				ev := strings.Join(truncEvidence(r.Evidence, 3), ", ")
+				lines = append(lines, m.styles.Footer.Render("      ‹ "+ev+" ›"))
+			}
+		}
+	}
+
+	if len(p.approved) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, m.styles.System.Render(
+			fmt.Sprintf("Other approvals this session (%d)", len(p.approved))))
+		max := 6
+		shown := p.approved
+		if len(shown) > max {
+			shown = shown[:max]
+		}
+		for _, a := range shown {
+			lines = append(lines, m.styles.Footer.Render("  "+a))
+		}
+		if len(p.approved) > max {
+			lines = append(lines, m.styles.Footer.Render(
+				fmt.Sprintf("  … and %d more", len(p.approved)-max)))
+		}
+	}
+
+	lines = append(lines, "")
+	lines = append(lines, m.styles.Footer.Render(
+		"[↑/↓] move  [space] toggle  [enter] persist checked  [esc] cancel"))
+	return m.styles.InputBorder.Render(strings.Join(lines, "\n"))
+}
+
+// truncEvidence keeps the first n entries of evidence and adds an
+// ellipsis suffix when there are more, so the picker stays compact.
+func truncEvidence(ev []string, n int) []string {
+	if len(ev) <= n {
+		return ev
+	}
+	out := append([]string(nil), ev[:n]...)
+	out = append(out, fmt.Sprintf("(+%d more)", len(ev)-n))
+	return out
+}
+
+// plural is a tiny helper used by the picker copy; the permissions
+// package has its own internal helper, but we can't reach unexported
+// symbols across packages, so we keep this one here for the TUI side.
+func plural(n int, word string) string {
+	if n == 1 {
+		return "1 " + word
+	}
+	return fmt.Sprintf("%d %ss", n, word)
+}

--- a/internal/tui/permissions_picker_test.go
+++ b/internal/tui/permissions_picker_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 The Cogo Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/go-steer/cogo/internal/config"
+	"github.com/go-steer/cogo/internal/permissions"
+)
+
+// TestPermissionsPicker_EmptyApprovalsShowsMessage covers the early
+// return path: with no interactive approvals this session, /permissions
+// must NOT open an empty modal — it should write a system message into
+// chat and stay closed.
+func TestPermissionsPicker_EmptyApprovalsShowsMessage(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultConfig()
+	m := NewModel(cfg, nil, "dark")
+	m.Update(tea.WindowSizeMsg{Width: 100, Height: 24})
+	m.SessionApprovals = func() []permissions.ApprovalLog { return nil }
+
+	m.handlePermissionsCommand()
+	if m.permissionsPicker != nil {
+		t.Fatalf("picker should NOT open with zero approvals; got %+v", m.permissionsPicker)
+	}
+	last := m.history.Snapshot()[m.history.Len()-1]
+	if last.Role != RoleSystem || !strings.Contains(last.Text, "nothing to review") {
+		t.Errorf("expected system message about empty approval log; got %+v", last)
+	}
+}
+
+// TestPermissionsPicker_TogglesAndPersistsChosen pins the full flow:
+// recommendations land in the picker, space toggles them, enter
+// invokes PersistAllowPatterns with the toggled-on patterns ONLY.
+//
+// DO NOT silence this test. Both halves matter: if toggle gets
+// inverted, users persist patterns they didn't pick; if persist
+// doesn't fire, the user's confirm has no effect.
+func TestPermissionsPicker_TogglesAndPersistsChosen(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultConfig()
+	m := NewModel(cfg, nil, "dark")
+	m.Update(tea.WindowSizeMsg{Width: 100, Height: 24})
+
+	now := time.Now()
+	m.SessionApprovals = func() []permissions.ApprovalLog {
+		return []permissions.ApprovalLog{
+			{Tool: "bash", Key: "git status", Decision: permissions.DecisionAllowOnce, At: now},
+			{Tool: "bash", Key: "git log", Decision: permissions.DecisionAllowOnce, At: now},
+			{Tool: "read_file", Key: "go.mod", Decision: permissions.DecisionAllowOnce, At: now},
+		}
+	}
+
+	var persisted []string
+	m.PersistAllowPatterns = func(patterns []string) error {
+		persisted = append(persisted, patterns...)
+		return nil
+	}
+
+	m.handlePermissionsCommand()
+	if m.permissionsPicker == nil {
+		t.Fatalf("picker should open with non-empty approval log")
+	}
+	p := m.permissionsPicker
+	if len(p.recs) < 2 {
+		t.Fatalf("expected >= 2 recommendations from the test approval set; got %d:\n%+v", len(p.recs), p.recs)
+	}
+
+	// Cursor starts at 0; toggle the first row, skip the rest.
+	m.handlePermissionsPickerKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	if !p.selected[0] {
+		t.Errorf("space did not toggle row 0 on")
+	}
+	// Press enter; the picker closes and PersistAllowPatterns gets
+	// called with exactly the chosen pattern.
+	m.handlePermissionsPickerKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.permissionsPicker != nil {
+		t.Errorf("picker should close on enter; got %+v", m.permissionsPicker)
+	}
+	if len(persisted) != 1 {
+		t.Fatalf("PersistAllowPatterns called with %d patterns; want exactly 1\ngot: %v", len(persisted), persisted)
+	}
+	if persisted[0] != p.recs[0].Pattern {
+		t.Errorf("persisted pattern = %q; want toggled-on row %q", persisted[0], p.recs[0].Pattern)
+	}
+}
+
+// TestPermissionsPicker_EnterWithNothingSelectedNoOps covers the
+// "user opened the picker, looked, decided nothing to add" path:
+// PersistAllowPatterns must NOT be called with an empty list.
+func TestPermissionsPicker_EnterWithNothingSelectedNoOps(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultConfig()
+	m := NewModel(cfg, nil, "dark")
+	m.Update(tea.WindowSizeMsg{Width: 100, Height: 24})
+	now := time.Now()
+	m.SessionApprovals = func() []permissions.ApprovalLog {
+		return []permissions.ApprovalLog{
+			{Tool: "bash", Key: "ls -la", Decision: permissions.DecisionAllowOnce, At: now},
+		}
+	}
+	called := false
+	m.PersistAllowPatterns = func(patterns []string) error {
+		called = true
+		return nil
+	}
+	m.handlePermissionsCommand()
+	m.handlePermissionsPickerKey(tea.KeyMsg{Type: tea.KeyEnter}) // no toggles
+	if called {
+		t.Errorf("PersistAllowPatterns should not fire when nothing was toggled on")
+	}
+}

--- a/internal/tui/program.go
+++ b/internal/tui/program.go
@@ -232,6 +232,16 @@ func Run(ctx context.Context, cfg *config.Config, agentsDir string) (int, error)
 		return appendPathScope(agentsDir, req.PersistKey)
 	}
 
+	// Wire the gate's session approval log + the .agents/config.json
+	// persistence path so the /permissions slash command can review
+	// approvals and persist recommended allowlist entries.
+	m.SessionApprovals = gate.Approvals
+	if agentsDir != "" {
+		m.PersistAllowPatterns = func(patterns []string) error {
+			return appendPermissionsAllow(agentsDir, patterns)
+		}
+	}
+
 	// Mouse capture wires the wheel to viewport scrolling. Capturing
 	// mouse events also takes plain click-drag away from the terminal's
 	// native text selection, so users hold Shift to select. Disable via
@@ -325,5 +335,28 @@ func appendPathScope(agentsDir, pattern string) error {
 		}
 	}
 	cfg.PathScope.Allow = append(cfg.PathScope.Allow, pattern)
+	return config.Save(filepath.Join(agentsDir, config.ConfigFileName), cfg)
+}
+
+// appendPermissionsAllow adds one or more patterns to
+// .agents/config.json's permissions.allow list. Idempotent — duplicate
+// patterns are skipped silently so /permissions can be re-run without
+// growing the config file.
+func appendPermissionsAllow(agentsDir string, patterns []string) error {
+	cfg, err := config.Load(agentsDir)
+	if err != nil {
+		return err
+	}
+	existing := make(map[string]bool, len(cfg.Permissions.Allow))
+	for _, p := range cfg.Permissions.Allow {
+		existing[p] = true
+	}
+	for _, p := range patterns {
+		if existing[p] {
+			continue
+		}
+		cfg.Permissions.Allow = append(cfg.Permissions.Allow, p)
+		existing[p] = true
+	}
 	return config.Save(filepath.Join(agentsDir, config.ConfigFileName), cfg)
 }

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -63,6 +63,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.modelPicker != nil {
 			return m.handleModelPickerKey(msg)
 		}
+		// Permissions review picker takes the same precedence as the
+		// model picker — it replaces the input area while open.
+		if m.permissionsPicker != nil {
+			return m.handlePermissionsPickerKey(msg)
+		}
 		return m.handleKey(msg)
 	case confirmReqMsg:
 		// Show modal; remember the request so handleConfirmKey can
@@ -682,6 +687,8 @@ func (m *Model) handleSlash(action SlashAction, cmd, args string) (tea.Model, te
 		return m.handleReload()
 	case SlashMouse:
 		return m.handleMouseCommand(args)
+	case SlashPermissions:
+		return m.handlePermissionsCommand()
 	case SlashModel:
 		return m.handleModelCommand(args)
 	case SlashQuit:
@@ -838,6 +845,73 @@ func (m *Model) handleStreamChunk(msg streamChunkMsg) (tea.Model, tea.Cmd) {
 	}
 	m.history.AppendText(m.currentAssistantIdx, msg.Text)
 	m.refreshViewport()
+	return m, nil
+}
+
+// handlePermissionsCommand opens the /permissions review picker.
+// With no approval log yet, it short-circuits to a system message
+// so the user isn't met with an empty modal.
+func (m *Model) handlePermissionsCommand() (tea.Model, tea.Cmd) {
+	if m.SessionApprovals == nil {
+		m.history.Append(Message{Role: RoleSystem, Text: "Permissions review unavailable: this build has no session approval log wired up."})
+		m.refreshViewport()
+		return m, nil
+	}
+	approvals := m.SessionApprovals()
+	picker := newPermissionsPicker(approvals)
+	if picker == nil {
+		m.history.Append(Message{Role: RoleSystem, Text: "No interactive approvals this session yet — there's nothing to review."})
+		m.refreshViewport()
+		return m, nil
+	}
+	m.permissionsPicker = picker
+	return m, nil
+}
+
+// handlePermissionsPickerKey runs while the /permissions overlay is
+// open. Up/Down navigate; Space toggles the row; Enter persists the
+// selected patterns; Esc dismisses.
+func (m *Model) handlePermissionsPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.permissionsPicker == nil {
+		return m, nil
+	}
+	p := m.permissionsPicker
+	switch msg.String() {
+	case "up":
+		if p.cursor > 0 {
+			p.cursor--
+		}
+	case "down":
+		if p.cursor < len(p.recs)-1 {
+			p.cursor++
+		}
+	case " ":
+		if p.cursor >= 0 && p.cursor < len(p.selected) {
+			p.selected[p.cursor] = !p.selected[p.cursor]
+		}
+	case "esc":
+		m.permissionsPicker = nil
+	case "enter":
+		patterns := p.chosenPatterns()
+		m.permissionsPicker = nil
+		if len(patterns) == 0 {
+			m.history.Append(Message{Role: RoleSystem, Text: "Permissions review closed without persisting anything."})
+			m.refreshViewport()
+			return m, nil
+		}
+		if m.PersistAllowPatterns == nil {
+			m.history.Append(Message{Role: RoleError, Text: "Can't persist allowlist entries: no project root for .agents/config.json. Run cogo from a directory with an .agents/ folder."})
+			m.refreshViewport()
+			return m, nil
+		}
+		if err := m.PersistAllowPatterns(patterns); err != nil {
+			m.history.Append(Message{Role: RoleError, Text: "Persist failed: " + err.Error()})
+			m.refreshViewport()
+			return m, nil
+		}
+		m.history.Append(Message{Role: RoleSystem, Text: "Added to .agents/config.json permissions.allow:\n  " + strings.Join(patterns, "\n  ")})
+		m.refreshViewport()
+	}
 	return m, nil
 }
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -48,6 +48,8 @@ func (m *Model) View() string {
 		input = m.renderConfirmModal()
 	case m.modelPicker != nil:
 		input = m.renderModelPicker()
+	case m.permissionsPicker != nil:
+		input = m.renderPermissionsPicker()
 	default:
 		input = m.renderInput()
 	}


### PR DESCRIPTION
feat(tui): /permissions reviews session approvals + persists chosen ones

The permission modal's "always allow" path persists one entry at a
time; getting a useful permanent allowlist requires the user to
remember which patterns they kept saying yes to and add them by
hand. Wire a /permissions slash command (alias: /perms) that:

1. Logs every interactive approval the user makes during a session
   (Gate.recordApproval + Gate.Approvals).
2. Classifies the log into recommended `tool:glob` patterns:
   - bash commands sharing a leading verb -> "bash:git *"
   - file-tool paths sharing a directory  -> "read_file:internal/tui/**"
   - same exact key approved -> exact pattern, with a "pin if you'll
     keep doing it" reason
   - falls back to "tool:*" when nothing tighter applies
3. Opens an overlay (in place of the input area) showing each
   recommendation with a checkbox, evidence samples, and the broader
   audit log of every approval this session.
4. Toggle with [space], persist with [enter], cancel with [esc].
   Selected patterns get appended to .agents/config.json's
   permissions.allow block via appendPermissionsAllow (idempotent —
   duplicates are skipped silently).

Wire-up:

- Gate gains an ApprovalLog slice + Approvals() getter.
- recordApproval is called from each non-deny branch of prompt().
- recommend.go holds the deterministic classifier + a
  SortRecommendations helper that floats specific patterns above
  wildcards in the picker so the safer choices show first.
- The TUI gets a permissionsPicker overlay (mirrors modelPicker in
  shape), routed in Update via handlePermissionsPickerKey and
  rendered via renderPermissionsPicker.
- Model exposes SessionApprovals + PersistAllowPatterns hooks for
  the picker; program.go wires them to gate.Approvals and a new
  appendPermissionsAllow that updates .agents/config.json.

Tests pin the contracts under "do not silence":

- TestRecommend (table-driven): each classification branch — exact,
  bash-verb, file-prefix, tool-wide fallback, two-tool split,
  duplicate dedupe — produces the expected pattern.
- TestRecommend_FileToolPrefixDropsBasename guards a subtle case
  where the longest common prefix is a full filename; we must back
  off to the parent directory rather than emit "<file>/**".
- TestSortRecommendations pins specific-before-wildcard ordering.
- TestPermissionsPicker_EmptyApprovalsShowsMessage proves /permissions
  with no log writes a system message instead of opening an empty
  modal.
- TestPermissionsPicker_TogglesAndPersistsChosen pins the toggle +
  enter flow: PersistAllowPatterns gets called with EXACTLY the
  toggled-on patterns.
- TestPermissionsPicker_EnterWithNothingSelectedNoOps guards the
  "user opened, looked, decided not to add" path so we don't write
  empty entries.

Out of scope (deliberately): removing entries, denial recommendations,
LLM-driven suggestions. The deterministic classifier covers the
patterns dogfood actually produces.